### PR TITLE
gh-336 make transactions tab always refresh

### DIFF
--- a/Multisig/UI/Transactions/TransactionsList/TransactionListView.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionListView.swift
@@ -12,6 +12,10 @@ struct TransactionListView: Loadable {
     @ObservedObject
     var model: TransactionsViewModel
 
+    init(safe: Safe) {
+        model = TransactionsViewModel(safe: safe)
+    }
+
     var body: some View {
         ZStack {
             if model.transactionsList.isEmpty {

--- a/Multisig/UI/Transactions/TransactionsList/TransactionsView.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionsView.swift
@@ -9,11 +9,8 @@
 import SwiftUI
 
 struct TransactionsView: View {
-
     @FetchRequest(fetchRequest: Safe.fetchRequest().selected())
     var selectedSafe: FetchedResults<Safe>
-
-    var model = TransactionsViewModel()
 
     var body: some View {
         ZStack(alignment: .center) {
@@ -26,15 +23,8 @@ struct TransactionsView: View {
                     self.trackEvent(.transactionsNoSafe)
                 }
             } else {
-                LoadableView(TransactionListView(model: model))
+                LoadableView(TransactionListView(safe: selectedSafe.first!))
             }
-        }
-        .onReceive(selectedSafe.publisher) { safe in
-            // instead of re-creating the model, we re-assign the safe
-            // when it changes, because the body of this view is redrawn,
-            // and that is causing the unneeded reloading of the
-            // network request.
-            self.model.safe = safe
         }
     }
 }

--- a/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
@@ -20,17 +20,16 @@ class TransactionsViewModel: BasicLoadableViewModel {
 
     @Published var isLoadingNextPage: Bool = false
 
-    var safe: Safe? {
-        didSet {
-            guard oldValue != safe && safe != nil else {
-                return
-            }
-            reloadData()
-        }
+    let safe: Safe
+
+    init(safe: Safe) {
+        self.safe = safe
+        super.init()
+        reloadData()
     }
 
     override func reload() {
-        Just(safe!.address!)
+        Just(safe.address!)
             .compactMap { Address($0) }
             .setFailureType(to: Error.self)
             .flatMap { address in


### PR DESCRIPTION
Now when selecting different tabs they will always behave the same.
So I forced the transactions tab to always refresh data.