### PR TITLE
gh-335 small fix

### DIFF
--- a/Multisig/UI/Transactions/TransactionsList/TransactionListView.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionListView.swift
@@ -47,7 +47,8 @@ struct TransactionListView: Loadable {
             }
 
             if model.isLoadingNextPage {
-                ActivityIndicator(isAnimating: .constant(true), style: .medium).frame(idealWidth: .infinity, maxWidth: .infinity, alignment: .center)
+                ActivityIndicator(isAnimating: .constant(true), style: .medium)
+                    .frame(idealWidth: .infinity, maxWidth: .infinity, alignment: .center)
             }
         }
     }

--- a/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
@@ -89,7 +89,6 @@ class TransactionsViewModel: BasicLoadableViewModel {
             .receive(on: RunLoop.main)
             .sink(receiveCompletion: { completion in
                 if case .failure(let error) = completion {
-                    self.nextURL = nil
                     App.shared.snackbar.show(message: error.localizedDescription)
                 }
                 self.isLoadingNextPage = false


### PR DESCRIPTION
If pagination fails, it was not be triggered again because there was no "nextURL" anymore.
I changed it. Not use can re-trigger pagination by scrolling up and down again.