### PR TITLE
gh-432  removed pull to refresh from details

### DIFF
--- a/Multisig/UI/Transactions/TransactionsList/TransactionListView.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionListView.swift
@@ -34,7 +34,7 @@ struct TransactionListView: Loadable {
             ForEach(model.transactionsList.sections) { section in
                 Section(header: SectionHeader(section.name)) {
                     ForEach(section.transactions) { transaction in
-                        NavigationLink(destination: LoadableView(TransactionDetailsView(transaction: transaction))) {
+                        NavigationLink(destination: TransactionDetailsView(transaction: transaction)) {
                             TransactionCellView(transaction: transaction)
                         }.onAppear {
                             if self.model.isLast(transaction: transaction) && self.model.canLoadNext {


### PR DESCRIPTION
The only other place where this still present is loading tx details from the tapping of the push notification. I think we can leave it there.