### PR TITLE
Gh 579/fix loading

### DIFF
--- a/Multisig/UI/Assets/Balances/BalancesViewModel.swift
+++ b/Multisig/UI/Assets/Balances/BalancesViewModel.swift
@@ -16,7 +16,6 @@ class BalancesViewModel: BasicLoadableViewModel {
     init(safe: Safe) {
         self.safe = safe
         super.init()
-        reloadData()
     }
 
     override func reload() {

--- a/Multisig/UI/Assets/Collectibles/CollectiblesListViewModel.swift
+++ b/Multisig/UI/Assets/Collectibles/CollectiblesListViewModel.swift
@@ -27,7 +27,6 @@ class CollectiblesListViewModel: BasicLoadableViewModel {
     init(safe: Safe) {
         self.safe = safe
         super.init()
-        reloadData()
     }
 
     override func reload() {

--- a/Multisig/UI/ENS/EnterENSNameViewModel.swift
+++ b/Multisig/UI/ENS/EnterENSNameViewModel.swift
@@ -32,14 +32,16 @@ class EnterENSNameViewModel: ObservableObject {
         subscribers.forEach { $0.cancel() }
 
         $text
-            .map { v -> String in
+            .map { [weak self] v -> String in
+                guard let `self` = self else { return "" }
                 self.reset()
                 return v.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             .filter { !$0.isEmpty }
             .debounce(for: 0.5, scheduler: RunLoop.main)
             .removeDuplicates()
-            .tryMap { v -> String in
+            .tryMap { [weak self] v -> String in
+                guard let `self` = self else { return "" }
                 self.startResolving()
                 return v
             }

--- a/Multisig/UI/Safe Management/Edit Safe Name/EditSafeNameViewModel.swift
+++ b/Multisig/UI/Safe Management/Edit Safe Name/EditSafeNameViewModel.swift
@@ -35,7 +35,8 @@ class EditSafeNameViewModel: ObservableObject {
         $enteredText
             .dropFirst()
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .sink { [unowned self] value in
+            .sink { [weak self] value in
+                guard let `self` = self else { return }
                 self.isValid = !value.isEmpty
                 self.error = self.isValid == false ? "Name must not be empty" : ""
             }

--- a/Multisig/UI/Safe Management/Load Safe/EnterSafeAddress/EnterSafeAddressViewModel.swift
+++ b/Multisig/UI/Safe Management/Load Safe/EnterSafeAddress/EnterSafeAddressViewModel.swift
@@ -51,14 +51,16 @@ class EnterSafeAddressViewModel: ObservableObject {
         $text
             .filter { !$0.isEmpty }
             .removeDuplicates()
-            .map { v -> String in
+            .map { [weak self] v -> String in
+                guard let `self` = self else { return "" }
                 self.reset()
                 return v.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             .tryMap { text in
                 try Address(text, isERC681: true)
             }
-            .map { v -> Address in
+            .map { [weak self] v -> Address in
+                guard let `self` = self else { return .zero }
                 self.isAddress = true
                 self.displayText = v.checksummed
 

--- a/Multisig/UI/Safe Management/Load Safe/EnterSafeName/EnterSafeNameViewModel.swift
+++ b/Multisig/UI/Safe Management/Load Safe/EnterSafeName/EnterSafeNameViewModel.swift
@@ -31,7 +31,8 @@ class EnterSafeNameViewModel: ObservableObject {
         $enteredText
             .dropFirst()
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .sink { [unowned self] value in
+            .sink { [weak self] value in
+                guard let `self` = self else { return }
                 self.isValid = !value.isEmpty
             }
             .store(in: &subscribers)

--- a/Multisig/UI/Settings/Safe Settings/BasicSafeSettingsView.swift
+++ b/Multisig/UI/Settings/Safe Settings/BasicSafeSettingsView.swift
@@ -23,9 +23,14 @@ struct BasicSafeSettingsView: Loadable {
     var body: some View {
         List {
             Section(header: SectionHeader("SAFE NAME")) {
-                NavigationLink(destination: EditSafeNameView(
-                    address: safe.address ?? "",
-                    name: safe.name ?? "")) { Text(safe.name ?? "").body() }
+                NavigationLink(
+                    destination:
+                        EditSafeNameView(
+                            address: safe.address ?? "",
+                            name: safe.name ?? ""),
+                    label: {
+                        Text(safe.name ?? "").body()
+                    })
                     .frame(height: rowHeight)
             }
 

--- a/Multisig/UI/Settings/Safe Settings/BasicSafeSettingsView.swift
+++ b/Multisig/UI/Settings/Safe Settings/BasicSafeSettingsView.swift
@@ -14,10 +14,6 @@ struct BasicSafeSettingsView: Loadable {
 
     var safe: Safe { return model.safe }
 
-    init(safe: Safe) {
-        model = SafeSettingsViewModel(safe: safe)
-    }
-
     let rowHeight: CGFloat = 48
     
     var body: some View {
@@ -72,6 +68,6 @@ struct BasicSafeSettingsView: Loadable {
 
 struct BasicSafeSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        BasicSafeSettingsView(safe: Safe())
+        BasicSafeSettingsView(model: SafeSettingsViewModel(safe: Safe()))
     }
 }

--- a/Multisig/UI/Settings/Safe Settings/SafeSettingsView.swift
+++ b/Multisig/UI/Settings/Safe Settings/SafeSettingsView.swift
@@ -10,12 +10,17 @@ import SwiftUI
 import CoreData
 
 struct SafeSettingsView: View {
-    @FetchRequest(fetchRequest: Safe.fetchRequest().selected())
-    var selected: FetchedResults<Safe>
-    
+    var model: SafeSettingsViewModel?
+
+    init(safe: Safe?) {
+        if let safe = safe {
+            model = SafeSettingsViewModel(safe: safe)
+        }
+    }
+
     var body: some View {
         ZStack {
-            if selected.first == nil {
+            if model == nil {
                 // so it does not jump when switching Assets <-> Settings in the tap bar
                 AddSafeIntroView(padding: .top, -56).onAppear {
                     self.trackEvent(.settingsSafeNoSafe)
@@ -26,7 +31,7 @@ struct SafeSettingsView: View {
                         .edgesIgnoringSafeArea(.all)
                         .foregroundColor(Color.gnoWhite)
 
-                    LoadableView(BasicSafeSettingsView(safe: selected.first!))
+                    LoadableView(BasicSafeSettingsView(model: model!))
                 }
             }
         }
@@ -35,6 +40,6 @@ struct SafeSettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SafeSettingsView()
+        SafeSettingsView(safe: nil)
     }
 }

--- a/Multisig/UI/Settings/Safe Settings/SafeSettingsViewModel.swift
+++ b/Multisig/UI/Settings/Safe Settings/SafeSettingsViewModel.swift
@@ -15,7 +15,6 @@ class SafeSettingsViewModel: BasicLoadableViewModel {
     init(safe: Safe) {
         self.safe = safe
         super.init()
-//        reloadData()
     }
 
     override func reload() {

--- a/Multisig/UI/Settings/Safe Settings/SafeSettingsViewModel.swift
+++ b/Multisig/UI/Settings/Safe Settings/SafeSettingsViewModel.swift
@@ -15,7 +15,7 @@ class SafeSettingsViewModel: BasicLoadableViewModel {
     init(safe: Safe) {
         self.safe = safe
         super.init()
-        reloadData()
+//        reloadData()
     }
 
     override func reload() {

--- a/Multisig/UI/Settings/SettingsView.swift
+++ b/Multisig/UI/Settings/SettingsView.swift
@@ -9,13 +9,16 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @FetchRequest(fetchRequest: Safe.fetchRequest().selected())
+    var selected: FetchedResults<Safe>
+
 
     @State
     private var selection: Int? = 0
 
     var body: some View {
         TopTabView($selection) {
-            SafeSettingsView()
+            SafeSettingsView(safe: selected.first)
                 .gnoTabItem(id: 0) {
                     HStack {
                         Image("ico-safe-settings").frame(width: 24, height: 24)

--- a/Multisig/UI/Settings/SettingsView.swift
+++ b/Multisig/UI/Settings/SettingsView.swift
@@ -12,7 +12,6 @@ struct SettingsView: View {
     @FetchRequest(fetchRequest: Safe.fetchRequest().selected())
     var selected: FetchedResults<Safe>
 
-
     @State
     private var selection: Int? = 0
 

--- a/Multisig/UI/Transactions/TransactionDetails/TransactionDetailsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionDetails/TransactionDetailsViewModel.swift
@@ -28,7 +28,7 @@ class TransactionDetailsViewModel: BasicLoadableViewModel {
             self.isRefreshing = false
         } else {
             id = TransactionID(value: transaction.id)
-            reloadData()
+//            reloadData()
         }
     }
 

--- a/Multisig/UI/Transactions/TransactionDetails/TransactionDetailsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionDetails/TransactionDetailsViewModel.swift
@@ -48,7 +48,8 @@ class TransactionDetailsViewModel: BasicLoadableViewModel {
         if canLoadTransaction {
             Just(canLoadTransaction)
                 .receive(on: DispatchQueue.global())
-                .tryMap { canLoadTransaction -> TransactionViewModel in
+                .tryMap { [weak self] canLoadTransaction -> TransactionViewModel in
+                    guard let `self` = self else { return TransactionViewModel() }
                     let transaction = try self.transaction()
                     let viewModels = TransactionViewModel.create(from: transaction)
                     guard viewModels.count == 1, let viewModel = viewModels.first else {

--- a/Multisig/UI/Transactions/TransactionDetails/TransactionDetailsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionDetails/TransactionDetailsViewModel.swift
@@ -28,7 +28,6 @@ class TransactionDetailsViewModel: BasicLoadableViewModel {
             self.isRefreshing = false
         } else {
             id = TransactionID(value: transaction.id)
-//            reloadData()
         }
     }
 

--- a/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
@@ -27,7 +27,7 @@ class TransactionsViewModel: BasicLoadableViewModel {
     init(safe: Safe) {
         self.safe = safe
         super.init()
-        reloadData()
+//        reloadData()
     }
 
     override func reload() {

--- a/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
+++ b/Multisig/UI/Transactions/TransactionsList/TransactionsViewModel.swift
@@ -27,7 +27,6 @@ class TransactionsViewModel: BasicLoadableViewModel {
     init(safe: Safe) {
         self.safe = safe
         super.init()
-//        reloadData()
     }
 
     override func reload() {

--- a/Multisig/UI/UI Library/LoadableView.swift
+++ b/Multisig/UI/UI Library/LoadableView.swift
@@ -16,6 +16,7 @@ protocol LoadableViewModel: ObservableObject {
     var contentWasLoadedOnce: Bool { get set }
     var errorMessage: String? { get set }
     func reloadData()
+    func firstTimeLoad()
 }
 
 protocol Loadable: View {
@@ -98,13 +99,15 @@ struct LoadableView<Content: Loadable>: View {
     }
 
     var contentView: some View {
-        self.model.contentWasLoadedOnce = true
-        return content
+        content
+            .onAppear {
+                self.model.firstTimeLoad()
+            }
     }
 }
 
 class BasicLoadableViewModel: LoadableViewModel {
-    @Published var isLoading: Bool = true
+    @Published var isLoading: Bool = false
 
     @Published var isRefreshing: Bool = false {
         didSet {
@@ -121,6 +124,12 @@ class BasicLoadableViewModel: LoadableViewModel {
     var contentWasLoadedOnce: Bool = false
 
     var subscribers = Set<AnyCancellable>()
+
+    final func firstTimeLoad() {
+        if contentWasLoadedOnce { return }
+        contentWasLoadedOnce = true
+        reloadData()
+    }
 
     final func reloadData() {
         subscribers.forEach { $0.cancel() }

--- a/Multisig/UI/UI Library/LoadableView.swift
+++ b/Multisig/UI/UI Library/LoadableView.swift
@@ -99,10 +99,8 @@ struct LoadableView<Content: Loadable>: View {
     }
 
     var contentView: some View {
-        content
-            .onAppear {
-                self.model.firstTimeLoad()
-            }
+        self.model.firstTimeLoad()
+        return content
     }
 }
 


### PR DESCRIPTION
- Added weak selfs everywhere in closures that capture them using Combine
- Changed loadable to load only once when the view is shown

That changed the app behavior (communicated to Liliya already):
- Switching tabs does not reload the content
- Going in and out of transaction details keeps the transaction list not reloaded and scrolled to the cell that was selected.
- Somehow transaction list cell selection is not removed after coming back from the tx details
- One artifact is that transaction list is reloading whenever the Switch Safe opened (even if not switching the safe), but I'm ok with that

The content is reloaded on the app re-opening, as it was before.

Please checkout the branch and ran it on your device to check that crashes are gone (I could not reproduce them after my fixes).