### PR TITLE
gh-1140 add app tracking transparency

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -5489,8 +5489,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gnosis/SwiftCryptoTokenFormatter.git";
 			requirement = {
-				branch = "update-deps";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 		55D3FF63260B2550008ABD2B /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "5669f222e46c8134fb1f399c745fa6882b43532e",
-          "version": "1.3.8"
+          "revision": "4e31051c63cc0ddf10a25cf5318856c510cf77f4",
+          "version": "1.4.0"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "1c47ea135322768023ecdcc9db79bf3df821209f",
-          "version": "7.3.0"
+          "revision": "66f5945ac3a4c4ac268bf94c31f226116b14e327",
+          "version": "7.4.0"
         }
       },
       {

--- a/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "6caa3bbb0fa73782ac80fe198c06ba0c8ba08269",
-          "version": "7.8.0"
+          "revision": "b97bfcd2e5eecc7aa7e1aeb27d097d610876cf93",
+          "version": "7.11.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "e451106148d7842b1ef1ecfce98d07dd4cfa5f8b",
-          "version": "7.8.0"
+          "revision": "22cb3ab5588200b210ae01e42665f52ac4e8ad28",
+          "version": "7.11.1"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
         "state": {
           "branch": null,
-          "revision": "3615a4ca10961d82ed2b5459cd9a5cb5ebc03ff2",
-          "version": "8.3.1"
+          "revision": "369716b8d7518a530ce3c3a251436d72546debd8",
+          "version": "8.4.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/firebase/nanopb.git",
         "state": {
           "branch": null,
-          "revision": "c2d43e59d8ec880ed261366818f0cacc5c8cc2e6",
-          "version": "2.30907.0"
+          "revision": "7ee9ef9f627d85cbe1b8c4f49a3ed26eed216c77",
+          "version": "2.30908.0"
         }
       },
       {
@@ -176,9 +176,9 @@
         "package": "SwiftCryptoTokenFormatter",
         "repositoryURL": "https://github.com/gnosis/SwiftCryptoTokenFormatter.git",
         "state": {
-          "branch": "update-deps",
-          "revision": "44b53dec200f4050bf1d835f8d0e4bc9aa6cb936",
-          "version": null
+          "branch": null,
+          "revision": "6f605fd7bd61327a6006919e28bf3f0632d1c556",
+          "version": "1.1.0"
         }
       },
       {

--- a/Multisig/App/AppDelegate.swift
+++ b/Multisig/App/AppDelegate.swift
@@ -18,6 +18,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Tracker.shared.append(handler: ConsoleTracker())
         #endif
         Tracker.shared.append(handler: FirebaseTrackingHandler())
+
+        // When user modifies tracking app settings from phone settings the app restarts
         Tracker.shared.setTrackingEnabled(AppSettings.trackingEnabled)
 
         AppSettings.saveCurrentRunVersionNumber()

--- a/Multisig/Cross-layer/Analytics/FirebaseTrackingHandler.swift
+++ b/Multisig/Cross-layer/Analytics/FirebaseTrackingHandler.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import FirebaseAnalytics
+import Firebase
 
 final class FirebaseTrackingHandler: TrackingHandler {
 
@@ -78,6 +79,7 @@ final class FirebaseTrackingHandler: TrackingHandler {
 
     func setTrackingEnabled(_ value: Bool) {
         Analytics.setAnalyticsCollectionEnabled(value)
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(value)
     }
 
     /// Verifies that the name is correct.

--- a/Multisig/Info.plist
+++ b/Multisig/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.1</string>
+	<string>2.16.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CLIENT_GATEWAY_URL</key>
@@ -59,7 +59,7 @@
 	<key>NSFaceIDUsageDescription</key>
 	<string>This will allow Safe Multisig to access your Face ID to open app and sign transactions.</string>
 	<key>NSUserTrackingUsageDescription</key>
-	<string></string>
+	<string>We collect anonymized app usage data and crash reports to ensure the quality of our app.</string>
 	<key>PAY_FOR_CANCELLATION_URL</key>
 	<string>$(PAY_FOR_CANCELLATION_URL)</string>
 	<key>PRIVACY_URL</key>
@@ -158,5 +158,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>FirebaseCrashlyticsCollectionEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/Multisig/Info.plist
+++ b/Multisig/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.0</string>
+	<string>2.15.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>CLIENT_GATEWAY_URL</key>
@@ -58,6 +58,8 @@
 	<string>Safe need to use camera to scan QR code.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>This will allow Safe Multisig to access your Face ID to open app and sign transactions.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string></string>
 	<key>PAY_FOR_CANCELLATION_URL</key>
 	<string>$(PAY_FOR_CANCELLATION_URL)</string>
 	<key>PRIVACY_URL</key>

--- a/Multisig/Logic/Models/AppSettings.swift
+++ b/Multisig/Logic/Models/AppSettings.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import CoreData
+import AppTrackingTransparency
 
 extension AppSettings {
     static func current() -> AppSettings {
@@ -25,9 +26,20 @@ extension AppSettings {
     static var termsAccepted: Bool
 
     @AppSetting(\.trackingEnabled)
+    private static var _trackingEnabled: Bool
+
     static var trackingEnabled: Bool {
-        didSet {
+        set {
+            _trackingEnabled = newValue
             Tracker.shared.setTrackingEnabled(trackingEnabled)
+        } get {
+            let systemTrackingEnabled: Bool
+            if #available(iOS 14, *) {
+                systemTrackingEnabled = ATTrackingManager.trackingAuthorizationStatus == .authorized
+            } else {
+                systemTrackingEnabled = true
+            }
+            return _trackingEnabled && systemTrackingEnabled
         }
     }
 

--- a/Multisig/Logic/Models/Multisig.xcdatamodeld/Multisig.xcdatamodel/contents
+++ b/Multisig/Logic/Models/Multisig.xcdatamodeld/Multisig.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20E232" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AppSettings" representedClassName="AppSettings" syncable="YES" codeGenerationType="class">
         <attribute name="appReviewEventCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="dismissedImportKeyBanner" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -13,7 +13,7 @@
         <attribute name="passcodeOptions" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="passcodeWasSetAtLeastOnce" optional="YES" attributeType="Boolean" defaultValueString="NO"/>
         <attribute name="termsAccepted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="trackingEnabled" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="trackingEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
     </entity>
     <entity name="AppUser" representedClassName="AppUser" syncable="YES" codeGenerationType="class">
         <attribute name="accessBlockedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import AppTrackingTransparency
 
 class MainTabBarViewController: UITabBarController {
     private weak var transactionsSegementControl: SegmentViewController?
@@ -38,7 +39,16 @@ class MainTabBarViewController: UITabBarController {
         super.viewDidAppear(animated)
         guard appearsFirstTime else { return }
         appearsFirstTime = false
-        App.shared.appReview.pullAppReviewTrigger()
+        // request for users prior 2.15.0 release to confirm IDFA tracking
+        if #available(iOS 14, *) {
+            if AppSettings.termsAccepted && ATTrackingManager.trackingAuthorizationStatus == .notDetermined {
+                ATTrackingManager.requestTrackingAuthorization { _ in }
+            } else {
+                App.shared.appReview.pullAppReviewTrigger()
+            }
+        } else {
+            App.shared.appReview.pullAppReviewTrigger()
+        }
     }
     
     private func balancesTabViewController() -> UIViewController {

--- a/Multisig/UI/App/ViewControllerFactory.swift
+++ b/Multisig/UI/App/ViewControllerFactory.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import SwiftUI
+import AppTrackingTransparency
 
 enum ViewControllerFactory {
 
@@ -22,7 +23,20 @@ enum ViewControllerFactory {
             nav.modalPresentationStyle = .fullScreen
             nav.modalTransitionStyle = .crossDissolve
 
-            let start = LaunchView(acceptedTerms: .constant(false), onStart: { [weak nav] in
+            let start = LaunchView(acceptedTerms: .constant(false), onStart: { [weak nav] trackingEnabled in
+                AppSettings.trackingEnabled = trackingEnabled
+                if trackingEnabled {
+                    // https://firebase.google.com/docs/ios/supporting-ios-14
+                    // This is required only for IDFA that we do not use
+                    if #available(iOS 14, *) {
+                        ATTrackingManager.requestTrackingAuthorization { status in
+                            DispatchQueue.main.async {
+                                nav?.popViewController(animated: false)
+                            }
+                        }
+                        return
+                    }
+                }
                 nav?.popViewController(animated: false)
             })
             .environment(\.managedObjectContext, App.shared.coreDataStack.viewContext)

--- a/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
+++ b/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
@@ -39,7 +39,7 @@ struct LaunchView: View {
     @State
     var showTerms = false
 
-    var onStart: () -> Void = { }
+    var onStart: ((Bool) -> Void)?
 
     private let logoToTextSpacing: CGFloat = 40
     private let textToButtonSpacing: CGFloat = 60

--- a/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
+++ b/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
@@ -39,7 +39,7 @@ struct LaunchView: View {
     @State
     var showTerms = false
 
-    var onStart: ((Bool) -> Void)?
+    var onStart: () -> Void
 
     private let logoToTextSpacing: CGFloat = 40
     private let textToButtonSpacing: CGFloat = 60
@@ -90,10 +90,10 @@ struct LaunchView: View {
 struct LaunchView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            LaunchView(acceptedTerms: .constant(false), showTerms: true)
+            LaunchView(acceptedTerms: .constant(false), showTerms: true, onStart: {})
                 .previewDevice(PreviewDevice(rawValue: "iPhone SE (2nd generation)"))
                 .previewDisplayName("iPhone SE2")
-            LaunchView(acceptedTerms: .constant(false), showTerms: true)
+            LaunchView(acceptedTerms: .constant(false), showTerms: true, onStart: {})
                 .previewDevice(PreviewDevice(rawValue: "iPhone 11 Pro Max"))
                 .previewDisplayName("iPhone 11 Pro Max")
         }

--- a/Multisig/UI/SwiftUI/Onboarding/TermsView.swift
+++ b/Multisig/UI/SwiftUI/Onboarding/TermsView.swift
@@ -21,7 +21,7 @@ struct TermsView: View {
     @State
     private var showTerms = false
 
-    var onStart: () -> Void = { }
+    var onStart: ((Bool) -> Void)?
 
     private let topPadding: CGFloat = Spacing.extraLarge
     private let bottomPadding: CGFloat = Spacing.large
@@ -46,13 +46,12 @@ struct TermsView: View {
             }
 
             Button("Agree") {
-                agreeWithTerms()
+                agreeWithTerms(true)
             }
             .buttonStyle(GNOFilledButtonStyle())
 
             Button("Agree without Sharing Usage Data") {
-                agreeWithTerms()
-                AppSettings.trackingEnabled = false
+                agreeWithTerms(false)
             }
             .buttonStyle(GNOPlainButtonStyle())
         }
@@ -62,10 +61,10 @@ struct TermsView: View {
         .background(Color.secondaryBackground)
     }
 
-    private func agreeWithTerms() {
+    private func agreeWithTerms(_ trackingEnabled: Bool) {
         AppSettings.termsAccepted = true
         self.acceptedTerms = true
-        self.onStart()
+        self.onStart?(trackingEnabled)
     }
 
     struct BulletText: View {

--- a/Multisig/UI/SwiftUI/Onboarding/TermsView.swift
+++ b/Multisig/UI/SwiftUI/Onboarding/TermsView.swift
@@ -21,7 +21,7 @@ struct TermsView: View {
     @State
     private var showTerms = false
 
-    var onStart: ((Bool) -> Void)?
+    var onStart: () -> Void
 
     private let topPadding: CGFloat = Spacing.extraLarge
     private let bottomPadding: CGFloat = Spacing.large
@@ -46,12 +46,14 @@ struct TermsView: View {
             }
 
             Button("Agree") {
-                agreeWithTerms(true)
+                AppSettings.termsAccepted = true
+                self.acceptedTerms = true
+                self.onStart()
             }
             .buttonStyle(GNOFilledButtonStyle())
 
-            Button("Agree without Sharing Usage Data") {
-                agreeWithTerms(false)
+            Button("No Thanks") {
+                self.isAgreeWithTermsPresented = false
             }
             .buttonStyle(GNOPlainButtonStyle())
         }
@@ -59,12 +61,6 @@ struct TermsView: View {
         .padding(.bottom, bottomPadding)
         .padding(.horizontal)
         .background(Color.secondaryBackground)
-    }
-
-    private func agreeWithTerms(_ trackingEnabled: Bool) {
-        AppSettings.termsAccepted = true
-        self.acceptedTerms = true
-        self.onStart?(trackingEnabled)
     }
 
     struct BulletText: View {
@@ -90,6 +86,6 @@ struct TermsView: View {
 struct TermsView_Previews: PreviewProvider {
     static var previews: some View {
         TermsView(acceptedTerms: .constant(false),
-                  isAgreeWithTermsPresented: .constant(true))
+                  isAgreeWithTermsPresented: .constant(true), onStart: {})
     }
 }

--- a/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
+++ b/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import AppTrackingTransparency
 
 struct AdvancedAppSettings: View {
 
@@ -58,6 +59,13 @@ struct AdvancedAppSettings: View {
             VStack {
                 Toggle(isOn: $trackingEnabled.didSet { enabled in
                     AppSettings.trackingEnabled = enabled
+                    // https://firebase.google.com/docs/ios/supporting-ios-14
+                    // This is required only for IDFA that we do not use
+                    if #available(iOS 14, *) {
+                        if ATTrackingManager.trackingAuthorizationStatus == .notDetermined && enabled {
+                            ATTrackingManager.requestTrackingAuthorization { _ in }
+                        }
+                    }
                 }) {
                     Text("Share Usage Data").headline()
                 }

--- a/MultisigIntegrationTests/Info.plist
+++ b/MultisigIntegrationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.0</string>
+	<string>2.15.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/MultisigIntegrationTests/Info.plist
+++ b/MultisigIntegrationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.1</string>
+	<string>2.16.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/MultisigTests/Info.plist
+++ b/MultisigTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.0</string>
+	<string>2.15.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/MultisigTests/Info.plist
+++ b/MultisigTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.1</string>
+	<string>2.16.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.0</string>
+	<string>2.15.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.15.1</string>
+	<string>2.16.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
Initially I tried to make system allowance bounded to our switch, but it appeared to be simpler.
This request is only for activating IDFA that we do not use.
![image](https://user-images.githubusercontent.com/2284385/117150403-6a10b680-adb8-11eb-864c-3162d359768e.png)
