### PR TITLE
gh-1134 Fixed crash due to memory leak

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -332,8 +332,8 @@
 		0AEE149F2540233C00046EE7 /* UINibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEE149E2540233C00046EE7 /* UINibView.swift */; };
 		0AEEBC73258CDF9400F3A6F9 /* CollectibleDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEBC71258CDF9400F3A6F9 /* CollectibleDetailViewController.swift */; };
 		0AEEBC74258CDF9400F3A6F9 /* CollectibleDetailViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AEEBC72258CDF9400F3A6F9 /* CollectibleDetailViewController.xib */; };
-		0AEEBC7A258CE24A00F3A6F9 /* SVGView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEBC79258CE24A00F3A6F9 /* SVGView.swift */; };
-		0AEEBC80258CE25700F3A6F9 /* SVGView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AEEBC7F258CE25700F3A6F9 /* SVGView.xib */; };
+		0AEEBC7A258CE24A00F3A6F9 /* WebImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEBC79258CE24A00F3A6F9 /* WebImageView.swift */; };
+		0AEEBC80258CE25700F3A6F9 /* WebImageView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AEEBC7F258CE25700F3A6F9 /* WebImageView.xib */; };
 		0AF1C7F42540887300E28669 /* HeaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF1C7F22540887300E28669 /* HeaderViewController.swift */; };
 		0AF1C7F52540887300E28669 /* HeaderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AF1C7F32540887300E28669 /* HeaderViewController.xib */; };
 		0AF1C7FB25408A4D00E28669 /* SafeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF1C7FA25408A4D00E28669 /* SafeBarView.swift */; };
@@ -849,8 +849,8 @@
 		0AEE149E2540233C00046EE7 /* UINibView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINibView.swift; sourceTree = "<group>"; };
 		0AEEBC71258CDF9400F3A6F9 /* CollectibleDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectibleDetailViewController.swift; sourceTree = "<group>"; };
 		0AEEBC72258CDF9400F3A6F9 /* CollectibleDetailViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectibleDetailViewController.xib; sourceTree = "<group>"; };
-		0AEEBC79258CE24A00F3A6F9 /* SVGView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGView.swift; sourceTree = "<group>"; };
-		0AEEBC7F258CE25700F3A6F9 /* SVGView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SVGView.xib; sourceTree = "<group>"; };
+		0AEEBC79258CE24A00F3A6F9 /* WebImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebImageView.swift; sourceTree = "<group>"; };
+		0AEEBC7F258CE25700F3A6F9 /* WebImageView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WebImageView.xib; sourceTree = "<group>"; };
 		0AF1C7F22540887300E28669 /* HeaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderViewController.swift; sourceTree = "<group>"; };
 		0AF1C7F32540887300E28669 /* HeaderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HeaderViewController.xib; sourceTree = "<group>"; };
 		0AF1C7FA25408A4D00E28669 /* SafeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeBarView.swift; sourceTree = "<group>"; };
@@ -2116,8 +2116,8 @@
 				0A9275D425ADDF1500755881 /* CollecitbleSectionSeparatorView.xib */,
 				5596C03D25507F3C00EF23A5 /* CollectibleTableViewCell.swift */,
 				5596C03725507EAE00EF23A5 /* CollectibleTableViewCell.xib */,
-				0AEEBC79258CE24A00F3A6F9 /* SVGView.swift */,
-				0AEEBC7F258CE25700F3A6F9 /* SVGView.xib */,
+				0AEEBC79258CE24A00F3A6F9 /* WebImageView.swift */,
+				0AEEBC7F258CE25700F3A6F9 /* WebImageView.xib */,
 			);
 			path = CollectiblesViewController;
 			sourceTree = "<group>";
@@ -2629,7 +2629,7 @@
 				0AC60C8F2549C9F300A63AE2 /* SegmentView.xib in Resources */,
 				5596C03825507EAE00EF23A5 /* CollectibleTableViewCell.xib in Resources */,
 				0AF1C7F52540887300E28669 /* HeaderViewController.xib in Resources */,
-				0AEEBC80258CE25700F3A6F9 /* SVGView.xib in Resources */,
+				0AEEBC80258CE25700F3A6F9 /* WebImageView.xib in Resources */,
 				5596C059255081AE00EF23A5 /* CollectiblesHeaderView.xib in Resources */,
 				0A86EE7525CC2BC30059876E /* LoadingFooterView.xib in Resources */,
 				0AF1C81325408EA000E28669 /* SegmentViewController.xib in Resources */,
@@ -2929,7 +2929,7 @@
 				0A86EE5D25CC2B2B0059876E /* RetryFooterView.swift in Sources */,
 				0A3F34DB2477E4E900E872AF /* KeyboardAdaptive.swift in Sources */,
 				0AA9F1F42497BCA9005BD60F /* TokenInfo.swift in Sources */,
-				0AEEBC7A258CE24A00F3A6F9 /* SVGView.swift in Sources */,
+				0AEEBC7A258CE24A00F3A6F9 /* WebImageView.swift in Sources */,
 				0A93DD592445CC8A00688050 /* SceneDelegate.swift in Sources */,
 				0A6430E2247EC2C7006FD30A /* ConfigurationKey.swift in Sources */,
 				0A5307162543110300E8A270 /* ConfirmTransactionRequest.swift in Sources */,

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectibleDetailViewController.swift
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectibleDetailViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class CollectibleDetailViewController: UIViewController {
     @IBOutlet private weak var imageContainerView: UIView!
-    @IBOutlet private weak var svgView: SVGView!
+    @IBOutlet private weak var imageView: WebImageView!
 
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var detailLabel: UILabel!
@@ -27,15 +27,15 @@ class CollectibleDetailViewController: UIViewController {
         detailLabel.setStyle(.footnote2)
         descriptionLabel.setStyle(.primary)
 
-        svgView.layer.cornerRadius = 10
-        svgView.clipsToBounds = true
+        imageView.layer.cornerRadius = 10
+        imageView.clipsToBounds = true
 
         titleLabel.text = collectible.name
         detailLabel.text = collectible.tokenID
         descriptionLabel.text = collectible.description
 
         if let url = collectible.imageURL {
-            svgView.setImage(url: url, placeholder: UIImage(named: "ico-collectible-placeholder"), onError: { [weak self] in
+            imageView.setImage(url: url, placeholder: UIImage(named: "ico-collectible-placeholder"), onError: { [weak self] in
                 self?.imageContainerView.isHidden = true
             })
         }
@@ -43,5 +43,4 @@ class CollectibleDetailViewController: UIViewController {
 
         addressView.setAddress(.init(exactly: collectible.address), label: "Asset Contract")
     }
-
 }

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectibleDetailViewController.xib
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectibleDetailViewController.xib
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -43,9 +41,9 @@
                                                     <rect key="frame" x="16" y="16" width="382" height="382"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="card-background" translatesAutoresizingMaskIntoConstraints="NO" id="IoM-Yq-SGD">
-                                                            <rect key="frame" x="-9" y="-8" width="402" height="402"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="382" height="382"/>
                                                         </imageView>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XIh-OK-2DI" userLabel="SVG View" customClass="SVGView" customModule="Multisig" customModuleProvider="target">
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XIh-OK-2DI" userLabel="SVG View" customClass="WebImageView" customModule="Multisig" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="382" height="382"/>
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         </view>

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectibleTableViewCell.swift
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectibleTableViewCell.swift
@@ -11,15 +11,15 @@ import UIKit
 class CollectibleTableViewCell: UITableViewCell {
     @IBOutlet private weak var cellNameLabel: UILabel!
     @IBOutlet private weak var cellDescriptionLabel: UILabel!
-    @IBOutlet private weak var cellSVGView: SVGView!
+    @IBOutlet private weak var cellImageView: WebImageView!
 
     override func awakeFromNib() {
         super.awakeFromNib()
         cellNameLabel.setStyle(.headline)
         cellDescriptionLabel.setStyle(.primary)
-        cellSVGView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMinXMinYCorner]
-        cellSVGView.layer.cornerRadius = 8
-        cellSVGView.clipsToBounds = true
+        cellImageView.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMinXMinYCorner]
+        cellImageView.layer.cornerRadius = 8
+        cellImageView.clipsToBounds = true
     }
     
     func setName(_ value: String) {
@@ -31,6 +31,6 @@ class CollectibleTableViewCell: UITableViewCell {
     }
 
     func setImage(with url: URL?, placeholder: UIImage) {
-        cellSVGView.setImage(url: url, placeholder: placeholder)
+        cellImageView.setImage(url: url, placeholder: placeholder)
     }
 }

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectibleTableViewCell.xib
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectibleTableViewCell.xib
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,12 +16,12 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tertiary-card-background" translatesAutoresizingMaskIntoConstraints="NO" id="ZpE-xX-bRz">
-                        <rect key="frame" x="7" y="-2" width="507" height="170"/>
+                        <rect key="frame" x="16" y="6" width="487" height="150"/>
                     </imageView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Uo4-L9-zv1">
                         <rect key="frame" x="16" y="6" width="487" height="150"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JUO-dL-AL2" customClass="SVGView" customModule="Multisig" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JUO-dL-AL2" customClass="WebImageView" customModule="Multisig" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="150" height="150"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectiblesHeaderView.xib
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectiblesHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectiblesViewController.swift
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectiblesViewController.swift
@@ -39,6 +39,23 @@ class CollectiblesViewController: LoadableViewController, UITableViewDelegate, U
 
         emptyView.setText("Collectibles will appear here")
         emptyView.setImage(UIImage(named: "ico-no-collectibles")!)
+
+        let gs = UITapGestureRecognizer(target: self, action: #selector(scrollToBottom))
+        gs.numberOfTapsRequired = 3
+        tableView.addGestureRecognizer(gs)
+    }
+
+    @objc func scrollToBottom() {
+//        tableView.setContentOffset(
+//            CGPoint(x: tableView.bounds.minX, y: ),
+//            animated: false)
+        let numSections = tableView.numberOfSections
+        if numSections > 0 {
+            let numRows = tableView.numberOfRows(inSection: numSections - 1)
+            if numRows > 0 {
+                tableView.scrollToRow(at: IndexPath(row: numRows - 1, section: numSections - 1), at: .bottom, animated: true)
+            }
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Multisig/UI/Assets/CollectiblesViewController/CollectiblesViewController.swift
+++ b/Multisig/UI/Assets/CollectiblesViewController/CollectiblesViewController.swift
@@ -39,23 +39,6 @@ class CollectiblesViewController: LoadableViewController, UITableViewDelegate, U
 
         emptyView.setText("Collectibles will appear here")
         emptyView.setImage(UIImage(named: "ico-no-collectibles")!)
-
-        let gs = UITapGestureRecognizer(target: self, action: #selector(scrollToBottom))
-        gs.numberOfTapsRequired = 3
-        tableView.addGestureRecognizer(gs)
-    }
-
-    @objc func scrollToBottom() {
-//        tableView.setContentOffset(
-//            CGPoint(x: tableView.bounds.minX, y: ),
-//            animated: false)
-        let numSections = tableView.numberOfSections
-        if numSections > 0 {
-            let numRows = tableView.numberOfRows(inSection: numSections - 1)
-            if numRows > 0 {
-                tableView.scrollToRow(at: IndexPath(row: numRows - 1, section: numSections - 1), at: .bottom, animated: true)
-            }
-        }
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Multisig/UI/Assets/CollectiblesViewController/WebImageView.xib
+++ b/Multisig/UI/Assets/CollectiblesViewController/WebImageView.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="SVGView" customModule="Multisig" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="WebImageView" customModule="Multisig" customModuleProvider="target">
             <connections>
                 <outlet property="imageView" destination="vPl-bI-M2F" id="gwE-74-9xm"/>
                 <outlet property="webView" destination="Kh8-6t-HJI" id="Dc5-Xb-LFA"/>


### PR DESCRIPTION
The reason it was crashing is that the UIImageView was loading a "gif" image and the image view implementation has a memory leak bug when you assign to it animated images. Replacing the image view with web view to show the "gif" files fixed the crash.