### PR TITLE
Gh 1196/test crash in prod

### DIFF
--- a/Multisig/Cross-layer/FirebaseRemoteConfig.swift
+++ b/Multisig/Cross-layer/FirebaseRemoteConfig.swift
@@ -15,6 +15,7 @@ class FirebaseRemoteConfig {
         case newestVersion
         case deprecatedSoon
         case deprecated
+        case crashDebugEnabled
     }
 
     private var remoteConfig: RemoteConfig!

--- a/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
+++ b/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
@@ -45,7 +45,7 @@ struct AdvancedAppSettings: View {
                         Text("Crash the App").body()
                     }
                 }
-             }
+            }
         }
         .onAppear {
             self.trackEvent(.settingsAppAdvanced)

--- a/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
+++ b/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
@@ -35,7 +35,8 @@ struct AdvancedAppSettings: View {
 
             DataSharingInfo()
 
-            if !(App.configuration.services.environment == .production) {
+            // NOTE: disabling to debug if crash reporting works in production
+            // if !(App.configuration.services.environment == .production) {
                 Section(header: SectionHeader("DEBUG")) {
                     Button(action: {
                         fatalError()
@@ -43,7 +44,7 @@ struct AdvancedAppSettings: View {
                         Text("Crash the App").body()
                     }
                 }
-            }
+            // } // end of 'if production'
         }
         .onAppear {
             self.trackEvent(.settingsAppAdvanced)

--- a/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
+++ b/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
@@ -35,8 +35,9 @@ struct AdvancedAppSettings: View {
 
             DataSharingInfo()
 
-            // NOTE: disabling to debug if crash reporting works in production
+            // NOTE: disabling to debug crash reporting in production environment
             // if !(App.configuration.services.environment == .production) {
+            if FirebaseRemoteConfig.shared.value(key: .crashDebugEnabled) == "YES" {
                 Section(header: SectionHeader("DEBUG")) {
                     Button(action: {
                         fatalError()
@@ -44,7 +45,7 @@ struct AdvancedAppSettings: View {
                         Text("Crash the App").body()
                     }
                 }
-            // } // end of 'if production'
+             }
         }
         .onAppear {
             self.trackEvent(.settingsAppAdvanced)

--- a/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
+++ b/Multisig/UI/SwiftUI/Settings/App Settings/AdvancedAppSettings.swift
@@ -36,8 +36,8 @@ struct AdvancedAppSettings: View {
             DataSharingInfo()
 
             // NOTE: disabling to debug crash reporting in production environment
-            // if !(App.configuration.services.environment == .production) {
-            if FirebaseRemoteConfig.shared.value(key: .crashDebugEnabled) == "YES" {
+            if !(App.configuration.services.environment == .production) ||
+                FirebaseRemoteConfig.shared.value(key: .crashDebugEnabled) == "YES" {
                 Section(header: SectionHeader("DEBUG")) {
                     Button(action: {
                         fatalError()


### PR DESCRIPTION
In prod environment, when the remote config `crashDebugEnabled` is set to `YES`, then the "Crash the app" button will appear.