### PR TITLE
Gh 1229/balances redesign

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -130,6 +130,13 @@
 		0A22E12725E4FA3200D24DE1 /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A22E12525E4FA3200D24DE1 /* SwitchTableViewCell.swift */; };
 		0A22E12825E4FA3200D24DE1 /* SwitchTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A22E12625E4FA3200D24DE1 /* SwitchTableViewCell.xib */; };
 		0A29B5622666808A0060F06A /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 0A29B5612666808A0060F06A /* FirebaseAnalyticsWithoutAdIdSupport */; };
+		0A2F1A6E267A538E00C09F03 /* GSLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2F1A6D267A538E00C09F03 /* GSLabel.swift */; };
+		0A2F1A70267A53A800C09F03 /* GSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2F1A6F267A53A800C09F03 /* GSButton.swift */; };
+		0A2F1A76267A5E5B00C09F03 /* BalanceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2F1A72267A5E5B00C09F03 /* BalanceCell.swift */; };
+		0A2F1A77267A5E5B00C09F03 /* BalanceCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A2F1A73267A5E5B00C09F03 /* BalanceCell.xib */; };
+		0A2F1A78267A5E5B00C09F03 /* TotalCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A2F1A74267A5E5B00C09F03 /* TotalCell.xib */; };
+		0A2F1A79267A5E5B00C09F03 /* TotalCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2F1A75267A5E5B00C09F03 /* TotalCell.swift */; };
+		0A2F1A7B267A5E9E00C09F03 /* GSImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2F1A7A267A5E9E00C09F03 /* GSImageView.swift */; };
 		0A339C5D24C1D16E00DAD84B /* Image+Blockies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A339C5C24C1D16E00DAD84B /* Image+Blockies.swift */; };
 		0A3DAD9426270F4D00743E38 /* unistring.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A3DAD9226270F4D00743E38 /* unistring.xcframework */; };
 		0A3DAD9526270F4D00743E38 /* idn2.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A3DAD9326270F4D00743E38 /* idn2.xcframework */; };
@@ -326,9 +333,17 @@
 		0ADDA20F245340540066457E /* CorrectAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDA20E245340540066457E /* CorrectAddressView.swift */; };
 		0ADDA2112453467A0066457E /* RoundedTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDA2102453467A0066457E /* RoundedTextField.swift */; };
 		0ADDB34E24518F8F0056B284 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDB34D24518F8F0056B284 /* ActivityIndicator.swift */; };
+		0ADFADA3267B496F007ACD65 /* BalancesTableViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADFADA2267B496F007ACD65 /* BalancesTableViewControllerTests.swift */; };
 		0AE061D62464560500CB60D7 /* Safe+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0476915A2464034D00D73D8B /* Safe+CoreDataProperties.swift */; };
 		0AE46C87257684B8001DC62B /* LoadSafeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE46C86257684B8001DC62B /* LoadSafeViewController.swift */; };
 		0AE46C8D257684DF001DC62B /* LoadSafeViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AE46C8C257684DF001DC62B /* LoadSafeViewController.xib */; };
+		0AE5A9BF267A4A3E00468C90 /* BalancesTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE5A9BE267A4A3E00468C90 /* BalancesTableViewController.swift */; };
+		0AE5A9C2267A4BDC00468C90 /* ImportKeyBannerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE5A9C0267A4BDC00468C90 /* ImportKeyBannerCell.swift */; };
+		0AE5A9C3267A4BDC00468C90 /* ImportKeyBannerCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AE5A9C1267A4BDC00468C90 /* ImportKeyBannerCell.xib */; };
+		0AE5A9C6267A4BEB00468C90 /* CreatePasscodeBannerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE5A9C4267A4BEB00468C90 /* CreatePasscodeBannerCell.swift */; };
+		0AE5A9C7267A4BEB00468C90 /* CreatePasscodeBannerCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AE5A9C5267A4BEB00468C90 /* CreatePasscodeBannerCell.xib */; };
+		0AE5A9C9267A4C2000468C90 /* BannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE5A9C8267A4C2000468C90 /* BannerView.swift */; };
+		0AE5A9CB267A4C2800468C90 /* BannerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AE5A9CA267A4C2800468C90 /* BannerView.xib */; };
 		0AE8C0442579317700E62B34 /* DetailDisclosingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE8C0422579317700E62B34 /* DetailDisclosingCell.swift */; };
 		0AE8C0452579317700E62B34 /* DetailDisclosingCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AE8C0432579317700E62B34 /* DetailDisclosingCell.xib */; };
 		0AE8C0562579328800E62B34 /* ExternalURLCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE8C0542579328800E62B34 /* ExternalURLCell.swift */; };
@@ -685,6 +700,13 @@
 		0A22E11B25E4FA2000D24DE1 /* PasscodeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasscodeSettingsViewController.swift; sourceTree = "<group>"; };
 		0A22E12525E4FA3200D24DE1 /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchTableViewCell.swift; sourceTree = "<group>"; };
 		0A22E12625E4FA3200D24DE1 /* SwitchTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwitchTableViewCell.xib; sourceTree = "<group>"; };
+		0A2F1A6D267A538E00C09F03 /* GSLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSLabel.swift; sourceTree = "<group>"; };
+		0A2F1A6F267A53A800C09F03 /* GSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSButton.swift; sourceTree = "<group>"; };
+		0A2F1A72267A5E5B00C09F03 /* BalanceCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BalanceCell.swift; sourceTree = "<group>"; };
+		0A2F1A73267A5E5B00C09F03 /* BalanceCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BalanceCell.xib; sourceTree = "<group>"; };
+		0A2F1A74267A5E5B00C09F03 /* TotalCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TotalCell.xib; sourceTree = "<group>"; };
+		0A2F1A75267A5E5B00C09F03 /* TotalCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TotalCell.swift; sourceTree = "<group>"; };
+		0A2F1A7A267A5E9E00C09F03 /* GSImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GSImageView.swift; sourceTree = "<group>"; };
 		0A339C5C24C1D16E00DAD84B /* Image+Blockies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Blockies.swift"; sourceTree = "<group>"; };
 		0A35CC2F24810CF6005E45BA /* ExportOptions.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = ExportOptions.plist; sourceTree = "<group>"; };
 		0A3DAD9226270F4D00743E38 /* unistring.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = unistring.xcframework; sourceTree = "<group>"; };
@@ -886,8 +908,16 @@
 		0ADDA20E245340540066457E /* CorrectAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectAddressView.swift; sourceTree = "<group>"; };
 		0ADDA2102453467A0066457E /* RoundedTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundedTextField.swift; sourceTree = "<group>"; };
 		0ADDB34D24518F8F0056B284 /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
+		0ADFADA2267B496F007ACD65 /* BalancesTableViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalancesTableViewControllerTests.swift; sourceTree = "<group>"; };
 		0AE46C86257684B8001DC62B /* LoadSafeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadSafeViewController.swift; sourceTree = "<group>"; };
 		0AE46C8C257684DF001DC62B /* LoadSafeViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LoadSafeViewController.xib; sourceTree = "<group>"; };
+		0AE5A9BE267A4A3E00468C90 /* BalancesTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalancesTableViewController.swift; sourceTree = "<group>"; };
+		0AE5A9C0267A4BDC00468C90 /* ImportKeyBannerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportKeyBannerCell.swift; sourceTree = "<group>"; };
+		0AE5A9C1267A4BDC00468C90 /* ImportKeyBannerCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ImportKeyBannerCell.xib; sourceTree = "<group>"; };
+		0AE5A9C4267A4BEB00468C90 /* CreatePasscodeBannerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePasscodeBannerCell.swift; sourceTree = "<group>"; };
+		0AE5A9C5267A4BEB00468C90 /* CreatePasscodeBannerCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CreatePasscodeBannerCell.xib; sourceTree = "<group>"; };
+		0AE5A9C8267A4C2000468C90 /* BannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerView.swift; sourceTree = "<group>"; };
+		0AE5A9CA267A4C2800468C90 /* BannerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BannerView.xib; sourceTree = "<group>"; };
 		0AE8C0422579317700E62B34 /* DetailDisclosingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDisclosingCell.swift; sourceTree = "<group>"; };
 		0AE8C0432579317700E62B34 /* DetailDisclosingCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailDisclosingCell.xib; sourceTree = "<group>"; };
 		0AE8C0542579328800E62B34 /* ExternalURLCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalURLCell.swift; sourceTree = "<group>"; };
@@ -1441,6 +1471,24 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		0A2F1A71267A552B00C09F03 /* BalancesV2 */ = {
+			isa = PBXGroup;
+			children = (
+				0A2F1A72267A5E5B00C09F03 /* BalanceCell.swift */,
+				0A2F1A73267A5E5B00C09F03 /* BalanceCell.xib */,
+				0A2F1A75267A5E5B00C09F03 /* TotalCell.swift */,
+				0A2F1A74267A5E5B00C09F03 /* TotalCell.xib */,
+				0AE5A9C8267A4C2000468C90 /* BannerView.swift */,
+				0AE5A9CA267A4C2800468C90 /* BannerView.xib */,
+				0AE5A9C0267A4BDC00468C90 /* ImportKeyBannerCell.swift */,
+				0AE5A9C1267A4BDC00468C90 /* ImportKeyBannerCell.xib */,
+				0AE5A9C4267A4BEB00468C90 /* CreatePasscodeBannerCell.swift */,
+				0AE5A9C5267A4BEB00468C90 /* CreatePasscodeBannerCell.xib */,
+				0AE5A9BE267A4A3E00468C90 /* BalancesTableViewController.swift */,
+			);
+			path = BalancesV2;
+			sourceTree = "<group>";
+		};
 		0A3DADAE26270FA900743E38 /* idn2 */ = {
 			isa = PBXGroup;
 			children = (
@@ -1581,6 +1629,7 @@
 				0A61E8412670E474009D68A4 /* CellTestViewController.swift */,
 				0A559A662672096B00E83A9E /* TotalBalanceTableViewCellTests.swift */,
 				0A559A6826720E5300E83A9E /* BannerTableViewCellTests.swift */,
+				0ADFADA2267B496F007ACD65 /* BalancesTableViewControllerTests.swift */,
 			);
 			path = "UI Snapshot Tests";
 			sourceTree = "<group>";
@@ -1951,6 +2000,7 @@
 				0A9E8E7625B9CA4200256AD3 /* BannerTableViewCell.xib */,
 				0AF1C91D2541DB3F00E28669 /* BalanceTableViewCell.swift */,
 				0AF1C91E2541DB3F00E28669 /* BalanceTableViewCell.xib */,
+				0A2F1A71267A552B00C09F03 /* BalancesV2 */,
 			);
 			path = BalancesViewController;
 			sourceTree = "<group>";
@@ -2472,6 +2522,9 @@
 		558835ED255BFEA80014E8C7 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0A2F1A7A267A5E9E00C09F03 /* GSImageView.swift */,
+				0A2F1A6F267A53A800C09F03 /* GSButton.swift */,
+				0A2F1A6D267A538E00C09F03 /* GSLabel.swift */,
 				558835EE255BFEDB0014E8C7 /* AddressInfoView.swift */,
 				55BCFC542554627100020CE7 /* BasicCell.swift */,
 				55BCFC5D255469B300020CE7 /* BasicHeaderView.swift */,
@@ -2782,6 +2835,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0A9E8E7825B9CA4200256AD3 /* BannerTableViewCell.xib in Resources */,
+				0AE5A9C7267A4BEB00468C90 /* CreatePasscodeBannerCell.xib in Resources */,
 				04B4B5F825B754D600CFE24B /* SafeLoadedViewController.xib in Resources */,
 				0AF1C8AB2541AE0600E28669 /* LoadingView.xib in Resources */,
 				0422007025EFDF4E00CAC173 /* TagView.xib in Resources */,
@@ -2799,6 +2853,7 @@
 				04B4B68F25B8857F00CFE24B /* SafeInfoViewV2.xib in Resources */,
 				0A86EE6F25CC2B4C0059876E /* RetryFooterView.xib in Resources */,
 				0AE8C06B2579371A00E62B34 /* DetailTransferInfoCell.xib in Resources */,
+				0AE5A9C3267A4BDC00468C90 /* ImportKeyBannerCell.xib in Resources */,
 				558836712565385F0014E8C7 /* RemoveSafeCell.xib in Resources */,
 				0AEEBC74258CDF9400F3A6F9 /* CollectibleDetailViewController.xib in Resources */,
 				0ADD19C2265EA23200EB0F2B /* SeedPhraseViewController.xib in Resources */,
@@ -2830,8 +2885,10 @@
 				0A6886ED258908150045CAB5 /* GNOTextField.xib in Resources */,
 				049A9D3B25F81F2C00CA5723 /* EditOwnerKeyViewController.xib in Resources */,
 				0ADD19A8265E53C600EB0F2B /* QRCodeView.xib in Resources */,
+				0A2F1A78267A5E5B00C09F03 /* TotalCell.xib in Resources */,
 				0A8AEB1125A4712B002A3FE1 /* ActionDetailTextCell.xib in Resources */,
 				0A478D5925B876AF0038363E /* ButtonTableViewCell.xib in Resources */,
+				0A2F1A77267A5E5B00C09F03 /* BalanceCell.xib in Resources */,
 				0428DA5B25CBFC25002CF4A9 /* HelpLinkTableViewCell.xib in Resources */,
 				0A3DADA526270FA100743E38 /* README.md in Resources */,
 				0AC60C8F2549C9F300A63AE2 /* SegmentView.xib in Resources */,
@@ -2869,6 +2926,7 @@
 				04626EB7265E6BBC00CC7FC8 /* OwnerKeyDetailsViewController.xib in Resources */,
 				550FB19326691C8F00C13D54 /* WCPedingConfirmationViewController.xib in Resources */,
 				0A5C2DCF25628277009808CB /* SafeInfoViewController.xib in Resources */,
+				0AE5A9CB267A4C2800468C90 /* BannerView.xib in Resources */,
 				550FB1A026691CA300C13D54 /* DappsViewController.xib in Resources */,
 				0AE8C08925793B8C00E62B34 /* DetailArrowPiece.xib in Resources */,
 				0AF1C80125408A6F00E28669 /* SafeBarView.xib in Resources */,
@@ -2971,6 +3029,7 @@
 				0468FB8825912E6800541536 /* HistoryTransactionsViewController.swift in Sources */,
 				55AC9E49248681A100B0BC24 /* LinkButton.swift in Sources */,
 				0A8AEB2025A4764F002A3FE1 /* ActionDetailAddressCell.swift in Sources */,
+				0AE5A9C2267A4BDC00468C90 /* ImportKeyBannerCell.swift in Sources */,
 				0AE8C0442579317700E62B34 /* DetailDisclosingCell.swift in Sources */,
 				0AD0273225A34E2F00886671 /* MultiSendListTableViewController.swift in Sources */,
 				5532D4BE2449A17D0067505A /* CrashlyticsLogger.swift in Sources */,
@@ -2985,6 +3044,8 @@
 				5532D4C12449A17D0067505A /* LogService.swift in Sources */,
 				0A9BC32F246022BD00EB9C5D /* ENS.swift in Sources */,
 				0A86EE6325CC2B350059876E /* LoadingFooterView.swift in Sources */,
+				0AE5A9C6267A4BEB00468C90 /* CreatePasscodeBannerCell.swift in Sources */,
+				0A2F1A7B267A5E9E00C09F03 /* GSImageView.swift in Sources */,
 				55D3654325078560004D5047 /* TextView.swift in Sources */,
 				0A451C18252DDCDE001DB7D2 /* ProgressIndicatorCell.swift in Sources */,
 				5532D4C32449A17D0067505A /* HTTPClient.swift in Sources */,
@@ -2993,6 +3054,7 @@
 				04D1323525E43C560032FA03 /* DetailRejectionInfoCell.swift in Sources */,
 				5556A03724489F37003EC861 /* CoreDataStack.swift in Sources */,
 				04B4B60225B84D6900CFE24B /* SafeInfoViewV2.swift in Sources */,
+				0A2F1A76267A5E5B00C09F03 /* BalanceCell.swift in Sources */,
 				04C97AB0246EEF1600EBA0F1 /* BrowserLink.swift in Sources */,
 				0A106287248A885E00C1EE54 /* ERC20Metadata.swift in Sources */,
 				0A0983A424BC5C93009EE296 /* BlockchainTokenStore.swift in Sources */,
@@ -3023,6 +3085,7 @@
 				0A22E12725E4FA3200D24DE1 /* SwitchTableViewCell.swift in Sources */,
 				0AF1C8A52541ADFF00E28669 /* LoadingView.swift in Sources */,
 				0468FB9625912E8300541536 /* TransactionListTableViewCell.swift in Sources */,
+				0AE5A9C9267A4C2000468C90 /* BannerView.swift in Sources */,
 				048AA142260D053400382E24 /* MainTabBarViewController.swift in Sources */,
 				0ACB4CD5256BC2B000845BF4 /* TransactionDetailsViewController.swift in Sources */,
 				5532D4BF2449A17D0067505A /* LoggableError.swift in Sources */,
@@ -3125,6 +3188,7 @@
 				0A57C5D72577F9E600420303 /* ConfirmationStatusPiece.swift in Sources */,
 				0AC60C892549C9D800A63AE2 /* SegmentView.swift in Sources */,
 				550FB1A526691CD800C13D54 /* SigningKeyTableViewCell.swift in Sources */,
+				0A2F1A70267A53A800C09F03 /* GSButton.swift in Sources */,
 				55B66E52247E478800249E98 /* LaunchView.swift in Sources */,
 				0AE8C08F25793B9400E62B34 /* DetailArrowPiece.swift in Sources */,
 				55CEFC1E24939503003B2B19 /* View+Tracking.swift in Sources */,
@@ -3226,6 +3290,7 @@
 				0A7AEAF62463189400014184 /* CenteredAddressWithLink.swift in Sources */,
 				043913A124BF4E480006517D /* BrowseLinkButton.swift in Sources */,
 				0A530720254311C400E8A270 /* SafeTransactionSigner.swift in Sources */,
+				0A2F1A6E267A538E00C09F03 /* GSLabel.swift in Sources */,
 				0A478D5825B876AF0038363E /* ButtonTableViewCell.swift in Sources */,
 				5503F62C2550625F0046545C /* CollectiblesViewController.swift in Sources */,
 				0A465C2E246C196900AFA467 /* Theme.swift in Sources */,
@@ -3243,6 +3308,7 @@
 				0ADB93FC24D31904006928DF /* SnackbarBottomPaddingModifier.swift in Sources */,
 				0AE8C06A2579371A00E62B34 /* DetailTransferInfoCell.swift in Sources */,
 				550FB1AD26691D6700C13D54 /* WCSession.swift in Sources */,
+				0AE5A9BF267A4A3E00468C90 /* BalancesTableViewController.swift in Sources */,
 				55413677265E4A0000796F91 /* AddOwnerKeyCell.swift in Sources */,
 				0AA9F2512498CC62005BD60F /* AddressString.swift in Sources */,
 				0468FB8725912E6800541536 /* FlatTransactionsListViewModel.swift in Sources */,
@@ -3280,6 +3346,7 @@
 				0A5F4829254C56580069C98D /* SafeEntryTableViewCell.swift in Sources */,
 				550FB1AE26691D6700C13D54 /* WCPendingTransaction.swift in Sources */,
 				555312E9250653800008206B /* BIP32HDNode.swift in Sources */,
+				0A2F1A79267A5E5B00C09F03 /* TotalCell.swift in Sources */,
 				0ADDA2112453467A0066457E /* RoundedTextField.swift in Sources */,
 				55BCFC5E255469B300020CE7 /* BasicHeaderView.swift in Sources */,
 				0A0EFCAC246EB32400D3D8BF /* CopyButton.swift in Sources */,
@@ -3324,6 +3391,7 @@
 			files = (
 				0A61E8422670E474009D68A4 /* CellTestViewController.swift in Sources */,
 				0A0983AD24BC6407009EE296 /* BlockchainTokenStoreIntegrationTests.swift in Sources */,
+				0ADFADA3267B496F007ACD65 /* BalancesTableViewControllerTests.swift in Sources */,
 				0A9BC35D2460581A00EB9C5D /* ENSIntegrationTests.swift in Sources */,
 				0A3DFEF82667D22B00B45770 /* MockSecureStore.swift in Sources */,
 				0A0983AF24BC66EB009EE296 /* BackendTokenStoreIntegrationTests.swift in Sources */,

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/BalanceCell.swift
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/BalanceCell.swift
@@ -1,0 +1,46 @@
+//
+//  BalanceCell.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 22.10.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+import Kingfisher
+
+class BalanceCell: UITableViewCell {
+    var mainText: String? {
+        get { cellMainLabel?.text }
+        set { cellMainLabel?.text = newValue }
+    }
+    var detailText: String? {
+        get { cellDetailLabel?.text }
+        set { cellDetailLabel?.text = newValue }
+    }
+    var subDetailText: String? {
+        get { cellSubDetailLabel?.text }
+        set { cellSubDetailLabel?.text = newValue }
+    }
+    var image: ImageData? {
+        get { cellImageView?.imageData }
+        set { cellImageView?.imageData = newValue }
+    }
+
+    @IBOutlet private weak var cellMainLabel: GSLabel!
+    @IBOutlet private weak var cellDetailLabel: GSLabel!
+    @IBOutlet private weak var cellSubDetailLabel: GSLabel!
+    @IBOutlet private weak var cellImageView: GSImageView!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        cellMainLabel.style = .primary
+        cellDetailLabel.style = .primary
+        cellSubDetailLabel.style = .footnote2
+
+        mainText = nil
+        detailText = nil
+        subDetailText = nil
+        image = nil
+    }
+}

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/BalanceCell.xib
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/BalanceCell.xib
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="BalanceCell" rowHeight="76" id="KGk-i7-Jjw" customClass="BalanceCell" customModule="Multisig" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YE3-hn-3h7" customClass="GSImageView" customModule="Multisig" customModuleProvider="target">
+                        <rect key="frame" x="20" y="16" width="28" height="28"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="28" id="6Kl-nK-4Z6"/>
+                            <constraint firstAttribute="height" constant="28" id="Eo8-LP-TfF"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a6g-6D-x6l" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                        <rect key="frame" x="56" y="0.0" width="194.5" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="5Oe-4f-zHg"/>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="cWl-KU-m9w"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="rL5-mS-zou">
+                        <rect key="frame" x="262.5" y="9.5" width="41.5" height="41"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hno-zE-SiG" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9sE-Qt-ruH" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="20.5" width="41.5" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <color key="backgroundColor" name="secondaryBackground"/>
+                <constraints>
+                    <constraint firstItem="a6g-6D-x6l" firstAttribute="leading" secondItem="YE3-hn-3h7" secondAttribute="trailing" constant="8" symbolic="YES" id="NuV-BC-XNy"/>
+                    <constraint firstItem="a6g-6D-x6l" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Qvz-X8-NZH"/>
+                    <constraint firstItem="rL5-mS-zou" firstAttribute="leading" secondItem="a6g-6D-x6l" secondAttribute="trailing" constant="12" id="WEq-OQ-2Ga"/>
+                    <constraint firstItem="rL5-mS-zou" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="exK-yc-6IS"/>
+                    <constraint firstAttribute="bottom" secondItem="a6g-6D-x6l" secondAttribute="bottom" id="n7l-DR-3sa"/>
+                    <constraint firstItem="YE3-hn-3h7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" symbolic="YES" id="tSZ-lC-s32"/>
+                    <constraint firstAttribute="trailing" secondItem="rL5-mS-zou" secondAttribute="trailing" constant="16" id="wJX-Mw-XPi"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <constraints>
+                <constraint firstItem="YE3-hn-3h7" firstAttribute="centerY" secondItem="njF-e1-oar" secondAttribute="centerY" id="FFJ-H4-BzG"/>
+            </constraints>
+            <connections>
+                <outlet property="cellDetailLabel" destination="Hno-zE-SiG" id="wpu-ek-o7s"/>
+                <outlet property="cellImageView" destination="YE3-hn-3h7" id="moF-qu-Fyp"/>
+                <outlet property="cellMainLabel" destination="a6g-6D-x6l" id="KMW-xB-bM5"/>
+                <outlet property="cellSubDetailLabel" destination="9sE-Qt-ruH" id="X2a-dB-fzH"/>
+            </connections>
+            <point key="canvasLocation" x="140.57971014492756" y="158.70535714285714"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="secondaryBackground">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/BalancesTableViewController.swift
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/BalancesTableViewController.swift
@@ -1,0 +1,202 @@
+//
+//  BalancesTableViewController.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class BalancesTableViewController: UITableViewController {
+
+    private var data: Balances = .empty
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // configure table view
+        tableView.allowsSelection = false
+        tableView.backgroundColor = .primaryBackground
+        tableView.refreshControl = makeRefreshControl()
+
+        // register cells
+        tableView.registerCell(ImportKeyBannerCell.self)
+        tableView.registerCell(CreatePasscodeBannerCell.self)
+        tableView.registerCell(TotalCell.self)
+        tableView.registerCell(BalanceCell.self)
+
+        // auto-sizing
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 60
+    }
+
+    private func makeRefreshControl() -> UIRefreshControl {
+        let control = UIRefreshControl()
+        return control
+    }
+
+    /// Updates the UI based on the new data
+    /// - Parameter newData: updated screen data
+    func reload(_ newData: Balances) {
+        data = newData
+
+        tableView.reloadData()
+
+        if data.isRefreshing {
+            tableView.refreshControl?.beginRefreshing()
+        } else if tableView.refreshControl?.isRefreshing == true {
+            tableView.refreshControl?.endRefreshing()
+        }
+    }
+
+    // MARK: UITableViewDataSource implementation
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        data.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cellData = data[indexPath]
+
+        switch cellData {
+
+        case is Balances.ImportKeyBannerPlaceholder:
+            return tableView.dequeueCell(ImportKeyBannerCell.self, for: indexPath)
+
+        case is Balances.PasscodeBannerPlaceholder:
+            return tableView.dequeueCell(CreatePasscodeBannerCell.self, for: indexPath)
+
+        case let total as Balances.Total:
+            let cell = tableView.dequeueCell(TotalCell.self, for: indexPath)
+            cell.detailText = total.quoteAmount
+            return cell
+
+        case let entry as Balances.Entry:
+            let cell = tableView.dequeueCell(BalanceCell.self, for: indexPath)
+            cell.mainText = entry.name
+            cell.detailText = entry.tokenAmount
+            cell.subDetailText = entry.quoteAmount
+            cell.image = entry.image
+            return cell
+
+        default:
+            return UITableViewCell()
+        }
+    }
+}
+
+// MARK: UI Data
+
+extension BalancesTableViewController {
+    /// UI data model for the controller
+    struct Balances {
+        static let empty = Balances()
+
+        /// Whether the refresh indicator is shown or not
+        var isRefreshing: Bool = false
+
+        /// If not nil, then a banner will be shown.
+        /// Only one banner at a time.
+        var banner: BannerPlaceholder?
+
+        /// If not nil, then the entries and total cells will be shown
+        var summary: Summary?
+
+        /// Creates cell data from the banner and summary
+        var cellData: [BalancesCellData] {
+            var items: [BalancesCellData] = []
+
+            if let banner = banner {
+                items.append(banner)
+            }
+
+            if let summary = summary {
+                items.append(summary.total)
+                items.append(contentsOf: summary.entries)
+            }
+
+            return items
+        }
+
+        /// Returns cell data for the row of the indexPath
+        subscript(indexPath: IndexPath) -> BalancesCellData {
+            cellData[indexPath.row]
+        }
+
+        /// Number of items in cell data
+        var count: Int {
+            cellData.count
+        }
+
+        // MARK: Data Types
+
+        /// Base type to describe cell data for the table view.
+        /// Use subclasses only (leafs).
+        class BalancesCellData {}
+
+        /// Banner base type. Use subclasses only.
+        class BannerPlaceholder: BalancesCellData {}
+
+        /// Represents "import key" banner
+        class ImportKeyBannerPlaceholder: BannerPlaceholder {}
+
+        /// Represents "create passcode" banner
+        class PasscodeBannerPlaceholder: BannerPlaceholder {}
+
+        /// Data for the "total" row
+        class Total: BalancesCellData {
+            /// Amount in quote currency (fiat)
+            var quoteAmount: String
+
+            init(_ value: String) {
+                quoteAmount = value
+            }
+        }
+
+        /// Data for the coin balance rows
+        class Entry: BalancesCellData {
+            /// Logo of the token
+            var image: ImageData
+            /// The name of the token
+            var name: String
+            /// Amount of tokens
+            var tokenAmount: String
+            /// Value of token amount in quote currency (fiat balance)
+            var quoteAmount: String
+
+            /// Creates new Entry
+            /// - Parameters:
+            ///   - image: token image
+            ///   - name: token name or symbol
+            ///   - tokenAmount: amount of tokens
+            ///   - quoteAmount: value of tokens in quote currency (fiat balance)
+            init(image: ImageData, name: String, tokenAmount: String, quoteAmount: String) {
+                self.image = image
+                self.name = name
+                self.tokenAmount = tokenAmount
+                self.quoteAmount = quoteAmount
+            }
+        }
+
+        /// Represents balance summary data
+        struct Summary {
+            /// Total value in quote currency
+            var total: Total
+            /// Token amounts
+            var entries: [Entry]
+
+            /// Creates balance summary if entries are not empty.
+            /// The "total" makes sense only if there are entries to show.
+            ///
+            /// - Parameters:
+            ///   - total: total value in quote currency
+            ///   - entries: token amounts. Must not be empty. If empty, then returns nil.
+            init?(total: Total, entries: [Entry]) {
+                if entries.isEmpty { return nil }
+                self.total = total
+                self.entries = entries
+            }
+        }
+    }
+}

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/BannerView.swift
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/BannerView.swift
@@ -1,0 +1,40 @@
+//
+//  BannerView.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class BannerView: UINibView {
+    var headerText: String? {
+        get { headerLabel?.text }
+        set { headerLabel?.text = newValue }
+    }
+    var bodyText: String? {
+        get { bodyLabel?.text }
+        set { bodyLabel?.text = newValue }
+    }
+    var buttonText: String? {
+        get { button.title(for: .normal) }
+        set { button.setTitle(newValue, for: .normal) }
+    }
+
+    @IBOutlet private weak var headerLabel: GSLabel!
+    @IBOutlet private weak var bodyLabel: GSLabel!
+    @IBOutlet private weak var button: GSButton!
+
+    override func commonInit() {
+        super.commonInit()
+
+        headerText = nil
+        bodyText = nil
+        buttonText = nil
+
+        headerLabel.style = .headline
+        bodyLabel.style = .primary
+        button.style = .plain
+    }
+}

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/BannerView.xib
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/BannerView.xib
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BannerView" customModule="Multisig" customModuleProvider="target">
+            <connections>
+                <outlet property="bodyLabel" destination="5u6-CT-bqz" id="l4a-92-q63"/>
+                <outlet property="button" destination="dCR-q7-enO" id="a3B-lo-dwX"/>
+                <outlet property="headerLabel" destination="eLB-1q-z0M" id="Xjv-dz-j9m"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" id="70M-qx-Zcv">
+            <rect key="frame" x="0.0" y="0.0" width="450" height="200"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" id="yr0-eP-enm">
+                    <rect key="frame" x="0.0" y="0.0" width="450" height="200"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="card-background" translatesAutoresizingMaskIntoConstraints="NO" id="hH6-QZ-yon">
+                            <rect key="frame" x="-9" y="-8" width="470" height="220"/>
+                            <color key="tintColor" name="secondaryBackground"/>
+                        </imageView>
+                        <stackView opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="r7X-gX-GEn">
+                            <rect key="frame" x="0.0" y="0.0" width="450" height="200"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="FCN-q1-OsD">
+                                    <rect key="frame" x="16" y="19" width="418" height="105"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="52R-gD-viN">
+                                            <rect key="frame" x="138" y="0.0" width="142.5" height="24"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="info.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="LhA-1k-Zg5">
+                                                    <rect key="frame" x="0.0" y="-2.5" width="24" height="28.5"/>
+                                                    <color key="tintColor" name="gray2"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="24" id="3tP-Sp-qTe"/>
+                                                        <constraint firstAttribute="width" constant="24" id="qY3-89-S2h"/>
+                                                    </constraints>
+                                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large" weight="bold"/>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Add owner key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eLB-1q-z0M" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                                                    <rect key="frame" x="30" y="0.0" width="112.5" height="24"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="We added signing support to the app! Now you can import your owner key and sign transactions on the go." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5u6-CT-bqz" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="34" width="418" height="71"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dCR-q7-enO" customClass="GSButton" customModule="Multisig" customModuleProvider="target">
+                                    <rect key="frame" x="16" y="134" width="418" height="50"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="KzY-D3-92Q"/>
+                                    </constraints>
+                                    <state key="normal" title="Add owner key now"/>
+                                </button>
+                            </subviews>
+                            <directionalEdgeInsets key="directionalLayoutMargins" top="19" leading="16" bottom="16" trailing="16"/>
+                        </stackView>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ycM-by-Cls">
+                            <rect key="frame" x="414" y="8" width="30" height="30"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="30" id="16u-fC-dSD"/>
+                                <constraint firstAttribute="height" constant="30" id="xjk-sB-p7h"/>
+                            </constraints>
+                            <color key="tintColor" name="gray2"/>
+                            <state key="normal" image="xmark" catalog="system">
+                                <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="medium" weight="semibold"/>
+                            </state>
+                        </button>
+                    </subviews>
+                    <viewLayoutGuide key="safeArea" id="7d1-dD-Ntg"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="ycM-by-Cls" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="eLB-1q-z0M" secondAttribute="trailing" constant="8" id="8NL-sM-TOD"/>
+                        <constraint firstAttribute="bottom" secondItem="r7X-gX-GEn" secondAttribute="bottom" id="8zh-Y1-kYt"/>
+                        <constraint firstAttribute="bottom" secondItem="hH6-QZ-yon" secondAttribute="bottom" id="ASI-Cx-DnI"/>
+                        <constraint firstItem="hH6-QZ-yon" firstAttribute="leading" secondItem="yr0-eP-enm" secondAttribute="leading" id="Hdk-rq-ks9"/>
+                        <constraint firstItem="ycM-by-Cls" firstAttribute="trailing" secondItem="r7X-gX-GEn" secondAttribute="trailing" constant="-6" id="Hz1-sT-3D9"/>
+                        <constraint firstAttribute="trailing" secondItem="r7X-gX-GEn" secondAttribute="trailing" id="UEm-wF-pLc"/>
+                        <constraint firstItem="ycM-by-Cls" firstAttribute="top" secondItem="r7X-gX-GEn" secondAttribute="top" constant="8" id="VFs-yR-sd3"/>
+                        <constraint firstItem="r7X-gX-GEn" firstAttribute="leading" secondItem="yr0-eP-enm" secondAttribute="leading" id="XGl-Dh-OyJ"/>
+                        <constraint firstAttribute="trailing" secondItem="hH6-QZ-yon" secondAttribute="trailing" id="pd3-gc-WFJ"/>
+                        <constraint firstItem="r7X-gX-GEn" firstAttribute="top" secondItem="yr0-eP-enm" secondAttribute="top" id="pjD-mJ-0G1"/>
+                        <constraint firstItem="hH6-QZ-yon" firstAttribute="top" secondItem="yr0-eP-enm" secondAttribute="top" id="sMS-Dn-Coz"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="MjW-UO-xav"/>
+            <point key="canvasLocation" x="19" y="15"/>
+        </stackView>
+    </objects>
+    <resources>
+        <image name="card-background" width="37" height="37"/>
+        <image name="info.circle" catalog="system" width="128" height="121"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
+        <namedColor name="gray2">
+            <color red="0.69411764705882351" green="0.70980392156862748" blue="0.69411764705882351" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="secondaryBackground">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/CreatePasscodeBannerCell.swift
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/CreatePasscodeBannerCell.swift
@@ -1,0 +1,20 @@
+//
+//  CreatePasscodeBannerCell.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class CreatePasscodeBannerCell: UITableViewCell {
+    @IBOutlet private weak var bannerView: BannerView!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        bannerView.headerText = "Create passcode"
+        bannerView.bodyText = "Secure your owner keys by setting up a passcode. The passcode will be needed to open the app and sign transactions."
+        bannerView.buttonText = "Create passcode now"
+    }
+}

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/CreatePasscodeBannerCell.xib
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/CreatePasscodeBannerCell.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="CreatePasscodeBannerCell" rowHeight="80" id="KGk-i7-Jjw" customClass="CreatePasscodeBannerCell" customModule="Multisig" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vaH-OC-gSg" customClass="BannerView" customModule="Multisig" customModuleProvider="target">
+                        <rect key="frame" x="16" y="20" width="288" height="40"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="vaH-OC-gSg" secondAttribute="trailing" constant="16" id="AHV-Zv-gSL"/>
+                    <constraint firstItem="vaH-OC-gSg" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="EPV-0B-ZdT"/>
+                    <constraint firstItem="vaH-OC-gSg" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="hCs-hp-uCe"/>
+                    <constraint firstAttribute="bottom" secondItem="vaH-OC-gSg" secondAttribute="bottom" constant="20" id="vxN-Vb-MRD"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="bannerView" destination="vaH-OC-gSg" id="0N6-5y-txl"/>
+            </connections>
+            <point key="canvasLocation" x="40.579710144927539" y="165.40178571428569"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/ImportKeyBannerCell.swift
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/ImportKeyBannerCell.swift
@@ -1,0 +1,20 @@
+//
+//  ImportKeyBannerCell.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class ImportKeyBannerCell: UITableViewCell {
+    @IBOutlet private weak var bannerView: BannerView!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        bannerView.headerText = "Add owner key"
+        bannerView.bodyText = "We added signing support to the app! Now you can import your owner key and sign transactions on the go."
+        bannerView.buttonText = "Add owner key now"
+    }
+}

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/ImportKeyBannerCell.xib
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/ImportKeyBannerCell.xib
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ImportKeyBannerCell" rowHeight="122" id="KGk-i7-Jjw" customClass="ImportKeyBannerCell" customModule="Multisig" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="122"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="122"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hAm-7I-Mhf" customClass="BannerView" customModule="Multisig" customModuleProvider="target">
+                        <rect key="frame" x="16" y="20" width="288" height="82"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="hAm-7I-Mhf" secondAttribute="bottom" constant="20" id="2va-1x-lSu"/>
+                    <constraint firstItem="hAm-7I-Mhf" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="AyQ-Cw-epz"/>
+                    <constraint firstItem="hAm-7I-Mhf" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="Py1-F0-RD4"/>
+                    <constraint firstAttribute="trailing" secondItem="hAm-7I-Mhf" secondAttribute="trailing" constant="16" id="yf3-M6-Qsu"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <connections>
+                <outlet property="bannerView" destination="hAm-7I-Mhf" id="sCU-Tr-Spr"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="179.46428571428569"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/TotalCell.swift
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/TotalCell.swift
@@ -1,0 +1,33 @@
+//
+//  TotalCell.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 03.11.20.
+//  Copyright © 2020 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class TotalCell: UITableViewCell {
+    var mainText: String? {
+        get { mainLabel?.text }
+        set { mainLabel?.text = newValue }
+    }
+    var detailText: String? {
+        get { detailLabel?.text }
+        set { detailLabel?.text = newValue }
+    }
+
+    @IBOutlet private weak var mainLabel: GSLabel!
+    @IBOutlet private weak var detailLabel: GSLabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        mainLabel.style = .headline
+        detailLabel.style = .headline
+
+        mainText = "Total"
+        detailText = nil
+    }
+}
+

--- a/Multisig/UI/Assets/BalancesViewController/BalancesV2/TotalCell.xib
+++ b/Multisig/UI/Assets/BalancesViewController/BalancesV2/TotalCell.xib
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="TotalCell" rowHeight="60" id="KGk-i7-Jjw" customClass="TotalCell" customModule="Multisig" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Mz-We-WXz" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                        <rect key="frame" x="16" y="0.0" width="60" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="kId-GM-ILB"/>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="quq-1h-e0L"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vJk-uN-ldB" customClass="GSLabel" customModule="Multisig" customModuleProvider="target">
+                        <rect key="frame" x="262" y="19.5" width="42" height="21"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="2Mz-We-WXz" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="AHQ-Tz-n1Y"/>
+                    <constraint firstAttribute="bottom" secondItem="2Mz-We-WXz" secondAttribute="bottom" id="Hwj-eq-zvd"/>
+                    <constraint firstItem="2Mz-We-WXz" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="UYF-50-ylG"/>
+                    <constraint firstItem="2Mz-We-WXz" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="lBN-dw-vON"/>
+                    <constraint firstAttribute="trailing" secondItem="vJk-uN-ldB" secondAttribute="trailing" constant="16" id="orV-QJ-Sld"/>
+                    <constraint firstItem="vJk-uN-ldB" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="poU-WR-62J"/>
+                    <constraint firstItem="vJk-uN-ldB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="2Mz-We-WXz" secondAttribute="trailing" constant="12" id="sU2-zp-HCl"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="detailLabel" destination="vJk-uN-ldB" id="w8b-2l-Qtx"/>
+                <outlet property="mainLabel" destination="2Mz-We-WXz" id="Xic-YJ-AlM"/>
+            </connections>
+            <point key="canvasLocation" x="140.57971014492756" y="157.36607142857142"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Multisig/UI/UI Library/View Controllers/LoadableViewController/LoadingView.xib
+++ b/Multisig/UI/UI Library/View Controllers/LoadableViewController/LoadingView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -30,7 +30,7 @@
     </objects>
     <resources>
         <namedColor name="primaryBackground">
-            <color red="0.96899998188018799" green="0.96100002527236938" blue="0.96100002527236938" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.96862745098039216" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/Multisig/UI/UI Library/View Controllers/LoadableViewController/ScrollableDataErrorView.xib
+++ b/Multisig/UI/UI Library/View Controllers/LoadableViewController/ScrollableDataErrorView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -91,7 +91,7 @@
     <resources>
         <image name="ico-server-error" width="24" height="24"/>
         <namedColor name="primaryBackground">
-            <color red="0.96899998188018799" green="0.96100002527236938" blue="0.96100002527236938" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.96862745098039216" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/Multisig/UI/UI Library/View Controllers/LoadableViewController/ScrollableEmptyView.xib
+++ b/Multisig/UI/UI Library/View Controllers/LoadableViewController/ScrollableEmptyView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -94,7 +94,7 @@
     <resources>
         <image name="ico-no-collectibles" width="136" height="110"/>
         <namedColor name="primaryBackground">
-            <color red="0.96899998188018799" green="0.96100002527236938" blue="0.96100002527236938" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.96862745098039216" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/Multisig/UI/UI Library/Views/GSButton.swift
+++ b/Multisig/UI/UI Library/Views/GSButton.swift
@@ -1,0 +1,75 @@
+//
+//  GSButton.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class GSButton: UIButton {
+    struct Style {
+        var font: UIFont
+        var config: [StateConfig]
+
+        struct StateConfig {
+            var state: UIControl.State
+            var titleColor: UIColor?
+            var backgroundImage: UIImage?
+        }
+    }
+
+    var style: Style? {
+        didSet {
+            if let style = style {
+
+                titleLabel?.font = style.font
+
+                for config in style.config {
+                    setTitleColor(config.titleColor, for: config.state)
+                    setBackgroundImage(config.backgroundImage, for: config.state)
+                }
+
+            }
+        }
+    }
+}
+
+extension GSButton.Style {
+    static let primary = GSButton.Style(
+        font: .gnoFont(forTextStyle: .primary),
+        config: [
+            StateConfig(state: .normal, titleColor: .button, backgroundImage: nil),
+            StateConfig(state: .highlighted, titleColor: .buttonPressed, backgroundImage: nil),
+            StateConfig(state: .disabled, titleColor: .button.withAlphaComponent(0.5), backgroundImage: nil)
+        ]
+    )
+
+    static let plain = GSButton.Style(
+        font: .gnoFont(forTextStyle: .headline2),
+        config: [
+            StateConfig(state: .normal, titleColor: .button, backgroundImage: nil),
+            StateConfig(state: .highlighted, titleColor: .buttonPressed, backgroundImage: nil),
+            StateConfig(state: .disabled, titleColor: .button.withAlphaComponent(0.5), backgroundImage: nil)
+        ]
+    )
+
+    static let filled = GSButton.Style(
+        font: .gnoFont(forTextStyle: .headline2),
+        config: [
+            StateConfig(state: .normal, titleColor: .primaryBackground, backgroundImage: UIImage(named: "btn-filled-normal")),
+            StateConfig(state: .highlighted, titleColor: .primaryBackground, backgroundImage: UIImage(named: "btn-filled-pressed")),
+            StateConfig(state: .disabled, titleColor: .primaryBackground, backgroundImage: UIImage(named: "btn-filled-inactive"))
+        ]
+    )
+
+    static let filledError = GSButton.Style(
+        font: .gnoFont(forTextStyle: .headline2),
+        config: [
+            StateConfig(state: .normal, titleColor: .primaryBackground, backgroundImage: UIImage(named: "btn-error-filled-normal")),
+            StateConfig(state: .highlighted, titleColor: .primaryBackground, backgroundImage: UIImage(named: "btn-error-filled-pressed")),
+            StateConfig(state: .disabled, titleColor: .primaryBackground, backgroundImage: UIImage(named: "btn-error-filled-inactive"))
+        ]
+    )
+}

--- a/Multisig/UI/UI Library/Views/GSImageView.swift
+++ b/Multisig/UI/UI Library/Views/GSImageView.swift
@@ -1,0 +1,66 @@
+//
+//  GSImageView.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+import Kingfisher
+
+class GSImageView: UIImageView {
+    var imageData: ImageData? {
+        didSet {
+            if let data = imageData {
+                data.apply(to: self)
+            } else {
+                image = nil
+            }
+        }
+    }
+}
+
+protocol ImageData {
+    var hasCircleShape: Bool { get set }
+    func apply(to imageView: UIImageView)
+}
+
+struct RemoteImageData: ImageData {
+    var url: URL
+    var placeholder: UIImage?
+    var error: UIImage?
+    var hasCircleShape: Bool
+    var completion: () -> Void
+
+    func apply(to imageView: UIImageView) {
+        let options: KingfisherOptionsInfo = [.processor(RoundCornerImageProcessor(radius: .widthFraction(0.5)))]
+        imageView.kf.setImage(
+            with: url,
+            placeholder: placeholder,
+            options: hasCircleShape ? options : nil) { [weak imageView] result in
+
+            guard let imageView = imageView else { return }
+
+            switch result {
+            case .success:
+                break
+            case .failure:
+                if let error = self.error {
+                    imageView.image = self.hasCircleShape ? error.circleShape() : error
+                }
+            }
+
+            self.completion()
+        }
+    }
+}
+
+struct LocalImageData: ImageData {
+    var image: UIImage?
+    var hasCircleShape: Bool = false
+
+    func apply(to imageView: UIImageView) {
+        imageView.image = hasCircleShape ? image?.circleShape() : image
+    }
+}

--- a/Multisig/UI/UI Library/Views/GSLabel.swift
+++ b/Multisig/UI/UI Library/Views/GSLabel.swift
@@ -1,0 +1,24 @@
+//
+//  GSLabel.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 16.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import UIKit
+
+class GSLabel: UILabel {
+    var style: GNOTextStyle? {
+        didSet {
+            if let style = style {
+                font = .gnoFont(forTextStyle: style)
+                textColor = style.color
+            } else {
+                font = .systemFont(ofSize: UIFont.systemFontSize)
+                textColor = .darkText
+            }
+        }
+    }
+}
+

--- a/MultisigIntegrationTests/UI Snapshot Tests/BalancesTableViewControllerTests.swift
+++ b/MultisigIntegrationTests/UI Snapshot Tests/BalancesTableViewControllerTests.swift
@@ -1,0 +1,173 @@
+//
+//  BalancesTableViewControllerTests.swift
+//  MultisigIntegrationTests
+//
+//  Created by Dmitry Bespalov on 17.06.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+import SnapshotTesting
+@testable import Multisig
+
+class BalancesTableViewControllerTests: XCTestCase {
+
+    /// Reusable test data to show some entries on the screen
+    let balanceSummary = BalancesTableViewController.Balances.Summary(
+        total: .init("7 000 000 EUR"),
+        entries:
+            .init(repeating:
+                    .init(image: LocalImageData(image: UIImage(named: "ico-token-placeholder")),
+                          name: "GNO",
+                          tokenAmount: "1",
+                          quoteAmount: "1 000 000 EUR"),
+                  count: 7
+            )
+    )
+
+    override func setUpWithError() throws {
+//        isRecording = true
+    }
+
+    func testWhenEmptyThenOk() {
+        let vc = BalancesTableViewController()
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+    }
+
+    func testWhen01EntryThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: false,
+            banner: nil,
+            summary: .init(
+                total: .init("1 000 000 EUR"),
+                entries: [
+                    .init(image: LocalImageData(image: UIImage(named: "ico-token-placeholder")),
+                          name: "GNO",
+                          tokenAmount: "1",
+                          quoteAmount: "1 000 000 EUR")
+                ]
+            )
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+    }
+
+    func testWhen03EntriesThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: false,
+            banner: nil,
+            summary: .init(
+                total: .init("3 000 000 EUR"),
+                entries: [
+                    .init(image: LocalImageData(image: UIImage(named: "ico-ether")),
+                          name: "ETH",
+                          tokenAmount: "1",
+                          quoteAmount: "1 000 000 EUR"),
+                    .init(image: LocalImageData(image: UIImage(named: "ico-token-placeholder")),
+                          name: "GNO",
+                          tokenAmount: "1",
+                          quoteAmount: "1 000 000 EUR"),
+                    .init(image: LocalImageData(image: UIImage(named: "ico-token-placeholder")),
+                          name: "OWL",
+                          tokenAmount: "1",
+                          quoteAmount: "1 000 000 EUR")
+                ]
+            )
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX, traits: UITraitCollection(userInterfaceStyle: .dark)))
+    }
+
+    func testWhen90EntriesThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: false,
+            banner: nil,
+            summary: .init(
+                total: .init("90 000 000 EUR"),
+                entries:
+                    .init(repeating:
+                            .init(image: LocalImageData(image: UIImage(named: "ico-token-placeholder")),
+                                  name: "GNO",
+                                  tokenAmount: "1",
+                                  quoteAmount: "1 000 000 EUR"),
+                          count: 90
+                    )
+            )
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(size: CGSize(width: 375, height: 6_000)))
+    }
+
+    func testWhenImportKeyBannerThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: false,
+            banner: BalancesTableViewController.Balances.ImportKeyBannerPlaceholder(),
+            summary: balanceSummary
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX, traits: UITraitCollection(userInterfaceStyle: .dark)))
+    }
+
+    func testWhenPasscodeBannerThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: false,
+            banner: BalancesTableViewController.Balances.PasscodeBannerPlaceholder(),
+            summary: balanceSummary
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX, traits: UITraitCollection(userInterfaceStyle: .dark)))
+    }
+
+    func testWhenRefreshingThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: true,
+            banner: nil,
+            summary: balanceSummary
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+    }
+
+    func testWhenStopsRefreshingThenOk() {
+        let vc = BalancesTableViewController()
+        var data = BalancesTableViewController.Balances(
+            isRefreshing: true,
+            banner: nil,
+            summary: balanceSummary
+        )
+        vc.reload(data)
+
+        data.isRefreshing = false
+        vc.reload(data)
+
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+    }
+
+    func testWhenLongStringsThenOk() {
+        let vc = BalancesTableViewController()
+        let data = BalancesTableViewController.Balances(
+            isRefreshing: false,
+            banner: nil,
+            summary: .init(
+                total: .init("1 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000 EUR"),
+                entries: [
+                    .init(image: LocalImageData(image: UIImage(named: "ico-token-placeholder")),
+                          name: "Gnosis DAO Token With Long Descriptive Name That Does Not Fit The Width",
+                          tokenAmount: "1 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000",
+                          quoteAmount: "1 000 000 000 000 000 000 000 000 000 000 000 000 000 000 000 EUR")
+                ]
+            )
+        )
+        vc.reload(data)
+        assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
+    }
+}

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen01EntryThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen01EntryThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5226ce741724a27edd510b41ff767d00e3794ebf4c5ed1a06db8f2f69efb6b7e
+size 76220

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen03EntriesThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen03EntriesThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:456a1c4e446a0c89cc8a6fdfb4dd536eda4ba88901efd35af34b38cdc9fbd9bf
+size 91789

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen03EntriesThenOk.2.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen03EntriesThenOk.2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a8b99b4226c87a3d2466b65b9261499a1bf5c2c2f9aa7d82370c72c86e427582
+size 96117

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen90EntriesThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhen90EntriesThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b77f06152bb969b0ba2f17d94e127db52434b7bb752e9fccdc90e31b6dc77e7
+size 1206006

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenEmptyThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenEmptyThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd0d398ba57fa2d8d84537db963ac5ebb93737eb2f3c4b0f7d605d522931e7fa
+size 60499

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenImportKeyBannerThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenImportKeyBannerThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c23c2b3f672f6d0429481cdb9fb2badef0e38f2c4710474e63e97226c2a70818
+size 178584

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenImportKeyBannerThenOk.2.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenImportKeyBannerThenOk.2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a12bc81df103a8630c3da31c9be2729e8df04b702d9cbae827684c2ba80b2db
+size 196181

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenLongStringsThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenLongStringsThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:090e4623ae91784f71805dc338d8bf91a4f5df8b7cacdc1b479b2c83410fd6e7
+size 81710

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenPasscodeBannerThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenPasscodeBannerThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68d17f3dfe6d28053be3dc912691d0b8227e11d6889ff8b36476f68b5f116ef4
+size 181707

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenPasscodeBannerThenOk.2.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenPasscodeBannerThenOk.2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6642d9e0422bac180f5c863cee49d196470cd54bc4fb42c5aff011b7f0551a1a
+size 199657

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenRefreshingThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenRefreshingThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7560185e55ae045210254288ce72d8ee7ecc49cd11e9d2aefdf1ebed8f85ca4b
+size 132790

--- a/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenStopsRefreshingThenOk.1.png
+++ b/MultisigIntegrationTests/UI Snapshot Tests/__Snapshots__/BalancesTableViewControllerTests/testWhenStopsRefreshingThenOk.1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a35358a0666ab099136d092a517248aabb9dfce9d4b344cb92548051437ea18
+size 126879

--- a/MultisigTests/Cross-layer/Logger/CrashlyticsLoggerTests.swift
+++ b/MultisigTests/Cross-layer/Logger/CrashlyticsLoggerTests.swift
@@ -54,4 +54,7 @@ class MockCrashlytics: CrashlyticsProtocol {
         // empty
     }
 
+    func setCrashlyticsCollectionEnabled(_ enabled: Bool) {
+        // empty
+    }
 }

--- a/MultisigTests/Logic/Models/Transaction/TransactionTests.swift
+++ b/MultisigTests/Logic/Models/Transaction/TransactionTests.swift
@@ -94,7 +94,7 @@ class TransactionTests: XCTestCase {
     }
 
     func testTransactoinEncodedData() throws {
-        let tx = Transaction(to: "0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66",
+        var tx = Transaction(to: "0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66",
                              value: "1000123",
                              data: "0x561001057600080fd5b5060405161060a3803806106",
                              operation: .delegate,
@@ -105,6 +105,8 @@ class TransactionTests: XCTestCase {
                              refundReceiver: AddressString(.zero),
                              nonce: "12305734256",
                              safeTxHash: nil)
+
+        tx.safe = "0x092CC1854399ADc38Dad4f846E369C40D0a40307"
 
         let domainHashInput = oneline("""
 035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749
@@ -134,8 +136,8 @@ ef8553f949acc5f0cb8002523b7a4f8e02664b6637eddc74ad72bb8e38588309
             Safe.domainData(for: "0x092CC1854399ADc38Dad4f846E369C40D0a40307").toHexString().lowercased(),
             domainHashInput.lowercased()
         )
-        XCTAssertEqual(
-            tx.encodeTransactionData(for: "0x092CC1854399ADc38Dad4f846E369C40D0a40307").toHexString().lowercased(),
+        XCTAssertEqual(            
+            tx.encodeTransactionData().toHexString().lowercased(),
             txHashInput.lowercased()
         )
     }


### PR DESCRIPTION
This is still work in progress. 

In this part I wanted to make the balances UIViewController testable with snapshot tests. That's why I went and re-designed it. You can see the [design documentation here](https://github.com/gnosis/safe-ios/blob/586af155efba0cf420857e695365dfe4eb548d8b/docs/Balances.pdf). 

The overall idea (not yet documented) was to go with view controllers for only display and getting user interaction events, and move all of the logic into testable controllers/logic objects (not created yet in this PR).