### PR TITLE
Gh 1349/data loss attempt1

### DIFF
--- a/Multisig/Logic/Models/KeyInfo.swift
+++ b/Multisig/Logic/Models/KeyInfo.swift
@@ -207,12 +207,6 @@ extension KeyInfo {
         try all().forEach { try $0.delete() }
     }
 
-    /// Deletes keys with matching addresses
-    /// - Parameter addresses: addresses of keys to delete
-    static func delete(addresses: [Address]) throws {
-        try keys(addresses: addresses).forEach { try $0.delete() }
-    }
-
     /// Saves the key to the persistent store
     func save() {
         App.shared.coreDataStack.saveContext()

--- a/Multisig/Logic/Models/KeyInfo.swift
+++ b/Multisig/Logic/Models/KeyInfo.swift
@@ -30,10 +30,6 @@ extension KeyInfo {
         set { type = Int16(newValue.rawValue) }
     }
 
-    var hasPrivateKey: Bool {
-        (try? privateKey()) != nil
-	}
-
     var displayName: String {
         name ?? "Key \(address.ellipsized())"
     }

--- a/Multisig/Logic/OwnerKeyController.swift
+++ b/Multisig/Logic/OwnerKeyController.swift
@@ -171,11 +171,24 @@ class OwnerKeyController {
                 try PrivateKey.deleteAll()
             }
 
-            // delete all device key infos whos private keys do not exist
-            let infos = try KeyInfo.keys(types: [.deviceImported, .deviceGenerated]).filter {
-                !$0.hasPrivateKey
+            // delete all device key infos with private keys that are missing
+            let keyInfoToDelete = try KeyInfo.keys(types: [.deviceImported, .deviceGenerated]).filter { info in
+                let shouldDelete: Bool
+                do {
+                    let keyOrNil = try info.privateKey()
+                    shouldDelete = keyOrNil == nil
+                } catch {
+                    // if error, then the key might still be there
+                    // but maybe data access failed for some reason (access while app is in background)
+                    // therefore we won't accidentally delete existing key
+                    shouldDelete = false
+                }
+                return shouldDelete
             }
-            try infos.forEach { try $0.delete() }
+
+            for info in keyInfoToDelete {
+                try info.delete()
+            }
         } catch {
             LogService.shared.error("Failed to delete all keys: \(error)")
         }
@@ -191,7 +204,7 @@ class OwnerKeyController {
         Tracker.trackEvent(.ownerKeyRemoved)
         Tracker.setNumKeys(KeyInfo.count(.deviceGenerated), type: .deviceGenerated)
         Tracker.setNumKeys(KeyInfo.count(.deviceImported), type: .deviceImported)
-        Tracker.setNumKeys(KeyInfo.count(.walletConnect), type: .deviceImported)
+        Tracker.setNumKeys(KeyInfo.count(.walletConnect), type: .walletConnect)
         NotificationCenter.default.post(name: .ownerKeyRemoved, object: nil)
     }
 }

--- a/Multisig/UI/Settings/SafeSettingsViewController/AdvancedSafeSettingsViewController.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/AdvancedSafeSettingsViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Version
 
 fileprivate protocol SectionItem {}
 
@@ -67,18 +68,28 @@ class AdvancedSafeSettingsViewController: UITableViewController {
     }
 
     private func buildSections() {
-        sections = [
+        sections = []
+
+        sections.append(
             (section: .fallbackHandler("FALLBACK HANDLER"),
              items: [Section.FallbackHandler.fallbackHandler(safe.fallbackHandlerInfo),
-                     Section.FallbackHandler.fallbackHandlerHelpLink]),
+                     Section.FallbackHandler.fallbackHandlerHelpLink])
+        )
 
-            (section: .guardInfo("GUARD"),
-             items: [Section.GuardInfo.guardInfo(safe.guardInfo),
-                     Section.GuardInfo.guardInfoHelpLink]),
+        if let contractVersion = safe.contractVersion,
+           let version = Version(contractVersion),
+           version >= Version(1, 3, 0) {
+            sections.append(
+                (section: .guardInfo("GUARD"),
+                 items: [Section.GuardInfo.guardInfo(safe.guardInfo),
+                         Section.GuardInfo.guardInfoHelpLink])
+            )
+        }
 
+        sections.append(
             (section: .nonce("NONCE"),
              items: [Section.Nonce.nonce(safe.nonce?.description ?? "0")])
-        ]
+        )
 
         if let modules = safe.modulesInfo, !modules.isEmpty {
             sections.append((section: .modules("ADDRESSES OF ENABLED MODULES"),


### PR DESCRIPTION
Handles #1349

Changes proposed in this pull request:
- Key cleanup on app startup seems to be the only place to suspect key removal. What could happen is that for some reason keychain is not accessible during the cleanup function and returned error. Then, because the error was treated as "no key exists", the key info could be deleted.
- Instead of ignoring errors, make the cleanup to only delete the keys for which private key is 100% does not exist after successful read operation.
- Also found a small tracking bug for the key number for the walletConnect
