### PR TITLE
Fix name typo

### DIFF
--- a/Multisig/UI/UI Library/Views/IdenticonView.swift
+++ b/Multisig/UI/UI Library/Views/IdenticonView.swift
@@ -36,7 +36,7 @@ extension KeyType {
         case .deviceGenerated:
             return "ico-key-type-seed"
         case .walletConnect:
-            return "ico-key-type-walletconnet"
+            return "ico-key-type-walletconnect"
         case .ledgerNanoX:
             return "ico-key-type-ledger"
         }


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix typo in name of wallet connect logo
