### PR TITLE
gh-1495 no message

### DIFF
--- a/Multisig/Logic/Ledger/BluetoothController.swift
+++ b/Multisig/Logic/Ledger/BluetoothController.swift
@@ -95,8 +95,6 @@ extension BluetoothController: CBCentralManagerDelegate {
             devices.append(device)
             delegate?.bluetoothControllerDidDiscover(device: device)
         }
-
-        centralManager.stopScan()
     }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {


### PR DESCRIPTION
Handles #1495

We stop scanning for devices once we have at least one device found.
I removed it. We need to stop it manually or it will be automatically stopped by releasing BluetoothController