### PR TITLE
Add Ribbon to advanced app settings and advanced safe settings

### DIFF
--- a/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
+++ b/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
@@ -245,6 +245,7 @@ class AppSettingsViewController: UITableViewController {
         case Section.Advanced.advanced:
             let advancedVC = AdvancedAppSettings()
             let hostingController = UIHostingController(rootView: advancedVC)
+            show(hostingController, sender: self)
 
         default:
             break

--- a/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
+++ b/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
@@ -245,8 +245,6 @@ class AppSettingsViewController: UITableViewController {
         case Section.Advanced.advanced:
             let advancedVC = AdvancedAppSettings()
             let hostingController = UIHostingController(rootView: advancedVC)
-            let ribbon = RibbonViewController(rootViewController: hostingController)
-            show(ribbon, sender: self)
 
         default:
             break

--- a/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
+++ b/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
@@ -245,7 +245,8 @@ class AppSettingsViewController: UITableViewController {
         case Section.Advanced.advanced:
             let advancedVC = AdvancedAppSettings()
             let hostingController = UIHostingController(rootView: advancedVC)
-            show(hostingController, sender: self)
+            let ribbon = RibbonViewController(rootViewController: hostingController)
+            show(ribbon, sender: self)
 
         default:
             break

--- a/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
@@ -258,7 +258,8 @@ class SafeSettingsViewController: LoadableViewController, UITableViewDelegate, U
             show(editSafeNameViewController, sender: self)
         case Section.Advanced.advanced(_):
             let advancedSafeSettingsViewController = AdvancedSafeSettingsViewController()
-            show(advancedSafeSettingsViewController, sender: self)
+            let ribbon = RibbonViewController(rootViewController: advancedSafeSettingsViewController)
+            show(ribbon, sender: self)
         default:
             break
         }


### PR DESCRIPTION
We decided to have the chain ribbon on the advanced Safe settings.

Changes proposed in this pull request:
- Add chain ribbon to advanced safe settings

 <img width="464" alt="image" src="https://user-images.githubusercontent.com/246473/138763037-e2c04b61-22e2-4a1c-b570-6105cdc970db.png">

