### PR TITLE
Fix top padding issue on advanced transaction details page

### DIFF
--- a/Multisig/UI/Transaction/TransactionDetailsViewController/AdvancedTransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/AdvancedTransactionDetailsViewController.swift
@@ -33,6 +33,11 @@ class AdvancedTransactionDetailsViewController: UITableViewController {
 
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 60
+        if #available(iOS 15.0, *) {
+            tableView.sectionHeaderTopPadding = 0
+        } else {
+            // Fallback on earlier versions
+        }
         tableView.estimatedSectionHeaderHeight = BasicHeaderView.headerHeight
         tableView.estimatedSectionFooterHeight = 0
 


### PR DESCRIPTION
before | after
----- | --------
![Simulator Screen Shot - iPhone 13 mini - 2021-11-25 at 10 43 59](https://user-images.githubusercontent.com/17750984/143418857-b9fb1929-8ae8-4ba4-9dd9-d444795e8cc5.png)  | ![Simulator Screen Shot - iPhone 13 mini - 2021-11-25 at 10 47 49](https://user-images.githubusercontent.com/17750984/143418916-88090f2b-35fe-4503-9887-7bdb5d327b7c.png)