### PR TITLE
Gh 1478/register push with delegate key

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		0A478D3C25B863D60038363E /* DerivedKeyTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A478D3A25B863D60038363E /* DerivedKeyTableViewCell.xib */; };
 		0A478D5825B876AF0038363E /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A478D5625B876AF0038363E /* ButtonTableViewCell.swift */; };
 		0A478D5925B876AF0038363E /* ButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A478D5725B876AF0038363E /* ButtonTableViewCell.xib */; };
+		0A4F44542754DE3D00423ABB /* GetDelegateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */; };
 		0A5307162543110300E8A270 /* ConfirmTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5307152543110300E8A270 /* ConfirmTransactionRequest.swift */; };
 		0A530720254311C400E8A270 /* SafeTransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A53071F254311C400E8A270 /* SafeTransactionSigner.swift */; };
 		0A5307462543273F00E8A270 /* UIViewController+UINib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5307452543273F00E8A270 /* UIViewController+UINib.swift */; };
@@ -805,6 +806,7 @@
 		0A478D3A25B863D60038363E /* DerivedKeyTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DerivedKeyTableViewCell.xib; sourceTree = "<group>"; };
 		0A478D5625B876AF0038363E /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
 		0A478D5725B876AF0038363E /* ButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ButtonTableViewCell.xib; sourceTree = "<group>"; };
+		0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDelegateRequest.swift; sourceTree = "<group>"; };
 		0A5307152543110300E8A270 /* ConfirmTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmTransactionRequest.swift; sourceTree = "<group>"; };
 		0A53071F254311C400E8A270 /* SafeTransactionSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeTransactionSigner.swift; sourceTree = "<group>"; };
 		0A5307452543273F00E8A270 /* UIViewController+UINib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+UINib.swift"; sourceTree = "<group>"; };
@@ -1315,6 +1317,7 @@
 				048643B224DAB5E3003DD966 /* UnregisterNotificationTokenRequest.swift */,
 				0ABC898E2576B857005D555B /* SCGModels.swift */,
 				0AB5DF8E270DD185005BFB43 /* CreateDelegateRequest.swift */,
+				0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */,
 			);
 			path = "Safe Client Gateway Service";
 			sourceTree = "<group>";
@@ -3481,6 +3484,7 @@
 				55B66E8C247FE13300249E98 /* SemitransparentBackgroundView.swift in Sources */,
 				0A0C607B255D83E80085C178 /* ViewControllerFactory.swift in Sources */,
 				043963832704E25800018F74 /* AdvancedTransactionDetailsViewController.swift in Sources */,
+				0A4F44542754DE3D00423ABB /* GetDelegateRequest.swift in Sources */,
 				0A0EFCA6246EAF3700D3D8BF /* DisplayURL.swift in Sources */,
 				55B66E89247FE09A00249E98 /* BottomOverlayView.swift in Sources */,
 				0AE8C0632579355800E62B34 /* TokenInfoView.swift in Sources */,

--- a/Multisig/App/RemoteNotificationHandler.swift
+++ b/Multisig/App/RemoteNotificationHandler.swift
@@ -192,11 +192,6 @@ class RemoteNotificationHandler {
 
         privateKeys += delegateKeys
 
-        guard !privateKeys.isEmpty,
-              !safes.isEmpty else {
-            return nil
-        }
-
         let hashPreimage = [
             "gnosis-safe",
             timestamp,

--- a/Multisig/App/RemoteNotificationHandler.swift
+++ b/Multisig/App/RemoteNotificationHandler.swift
@@ -173,7 +173,7 @@ class RemoteNotificationHandler {
     ///   - timestamp: Unix timestamp or nil. If nil, the current time will be used.
     /// - Throws: Error in case of database failures, or private key signing errors
     /// - Returns: If there are any keys, then returns preimage of the hash, the hash that was signed, timestamp used, and array of signatures corresponding to the signing keys.
-    static func sign(safes: [String], deviceID: String, token: String, timestamp: String) throws -> (preimage: String, hash: String, signatures: [String])? {
+    static func sign(safes: [String], deviceID: String, token: String, timestamp: String) throws -> (preimage: String, hash: String, signatures: [String]) {
 
         // sign the registration data by each private key.
         var privateKeys = try KeyInfo.keys(types: [.deviceImported, .deviceGenerated])
@@ -233,10 +233,11 @@ class RemoteNotificationHandler {
                     .compactMap { Address($0) }
                     .map { $0.checksummed }
                     .sorted()
-                guard let signResult = try Self.sign(safes: safes,
-                                                     deviceID: deviceID,
-                                                     token: pushToken,
-                                                     timestamp: timestamp) else { continue }
+                
+                let signResult = try Self.sign(safes: safes,
+                                               deviceID: deviceID,
+                                               token: pushToken,
+                                               timestamp: timestamp)
                 
                 safeRegistration.append(SafeRegistration(chainId: chainSafes.chain.id!, safes: safes,
                                                          signatures: signResult.signatures))

--- a/Multisig/Data/Services/Safe Client Gateway Service/CreateDelegateRequest.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/CreateDelegateRequest.swift
@@ -42,8 +42,8 @@ extension SafeClientGatewayService {
         signature: Data,
         label: String,
         chainId: String,
-        completion: @escaping (Result<CreateDelegateRequest.ResponseType, Error>
-    ) -> Void) -> URLSessionTask? {
+        completion: @escaping (Result<CreateDelegateRequest.ResponseType, Error>) -> Void
+    ) -> URLSessionTask? {
         asyncExecute(request: CreateDelegateRequest(safe: safe?.checksummed,
                                                     delegate: delegate.checksummed,
                                                     delegator: owner.checksummed,

--- a/Multisig/Data/Services/Safe Client Gateway Service/GetDelegateRequest.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/GetDelegateRequest.swift
@@ -1,0 +1,40 @@
+//
+//  GetDelegateRequest.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 29.11.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+struct GetDelegateRequest: JSONRequest {
+    let chainId: String
+    var safe: String?
+    var delegate: String?
+    var delegator: String?
+    var label: String?
+
+    var httpMethod: String { "GET" }
+    var urlPath: String { "/v1/chains/\(chainId)/delegates/" }
+
+    typealias ResponseType = Page<SCGModels.KeyDelegate>
+}
+
+extension SafeClientGatewayService {
+    func asyncCreateDelegate(
+        chainId: String,
+        safe: Address? = nil,
+        delegator: Address? = nil,
+        delegate: Address? = nil,
+        label: String? = nil,
+        completion: @escaping (Result<GetDelegateRequest.ResponseType, Error>) -> Void
+    ) -> URLSessionTask? {
+        asyncExecute(request: GetDelegateRequest(chainId: chainId,
+                                                 safe: safe?.checksummed,
+                                                 delegate: delegate?.checksummed,
+                                                 delegator: delegator?.checksummed,
+                                                 label: label),
+                     completion: completion)
+    }
+}

--- a/Multisig/Data/Services/Safe Client Gateway Service/SCGModels.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/SCGModels.swift
@@ -607,6 +607,14 @@ extension SCGModels {
         let latestNonce: UInt256String
         let safeTxGas: String
     }
+
+    struct KeyDelegate: Codable {
+        var safe: AddressString
+        var delegate: AddressString
+        var delegator: AddressString
+        var label: String
+    }
+
 }
 
 extension SCGModels.AddressInfo {

--- a/Multisig/UI/Settings/OwnerKeyManagement/LedgerOwnerKey/LedgerKeyAddedViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/LedgerOwnerKey/LedgerKeyAddedViewController.swift
@@ -128,6 +128,9 @@ class AddDelegateKeyController {
                         // post notification so that UI state can be updated
                         NotificationCenter.default.post(name: .ownerKeyUpdated, object: nil)
 
+                        // trigger push notification registration
+                        App.shared.notificationHandler.signingKeyUpdated()
+
                         self.completeProcess()
                         break
 

--- a/MultisigTests/Data/Services/Safe Transaction Service/RegisterNotificationTokenRequestTests.swift
+++ b/MultisigTests/Data/Services/Safe Transaction Service/RegisterNotificationTokenRequestTests.swift
@@ -26,7 +26,7 @@ class RegisterNotificationTokenRequestTests: XCTestCase {
             token: "erXBYb-CxU1jtSvwfZrxqW:APA91bH0IWkMWOGizlbNAwxV6OVjEmNR1feRs2WBT7BE6aVMm2C-x1COKqNYq19t5YNjIzVBKDyVVEqFojlkvEtiSaJA0lCZL0LfuEwfc8p9jfBuM6HG82pczVbnMev1J0gXlB3bIlAP",
             timestamp: "1606319110027")
 
-        XCTAssertEqual(signResult?.signatures, ["0x05a119049f1385fc1c8785389a7f7c7c1c104d54ce0225a856ca580c6085d45428d26bbf273b3fe5428a921a5fbc6658e024e87ac0a3291ba8015949c0e7945d1c"])
+        XCTAssertEqual(signResult.signatures, ["0x05a119049f1385fc1c8785389a7f7c7c1c104d54ce0225a856ca580c6085d45428d26bbf273b3fe5428a921a5fbc6658e024e87ac0a3291ba8015949c0e7945d1c"])
 
         try KeyInfo.deleteAll()
     }
@@ -43,7 +43,7 @@ class RegisterNotificationTokenRequestTests: XCTestCase {
             token: "dSh5Se1XgEiTiY-4cv1ixY:APA91bG3vYjy9VgB3X3u5EsBphJABchb8Xgg2cOSSekPsxDsfE5xyBeu6gKY0wNhbJHgQUQQGocrHx0Shbx6JMFx2VOyhJx079AduN01NWD1-WjQerY5s3l-cLnHoNNn8fJfARqSUb3G",
             timestamp: "1607013002")
 
-        XCTAssertEqual(signResult?.signatures, ["0x77a687a3e0021202c4d542a6aeccdb0a22bdcb722892d3a5082334d2c72468771a1e7aa303925a0115a09789c36a2a1e7bb5feb212bbd4db7c9f0c1ab01739291b"])
+        XCTAssertEqual(signResult.signatures, ["0x77a687a3e0021202c4d542a6aeccdb0a22bdcb722892d3a5082334d2c72468771a1e7aa303925a0115a09789c36a2a1e7bb5feb212bbd4db7c9f0c1ab01739291b"])
 
         try KeyInfo.deleteAll()
     }


### PR DESCRIPTION
Handles #1478

Changes proposed in this pull request:
- Registers for pushes with delegate keys
- Registers for pushes with empty signatures to remove 'sign request' notifications in the case when last key was deleted:
  - Have 1 key that is owner of a safe
  - Remove this key
  - App still received "sign request" notification
  - The reason is that when we don't get any keys locally, we won't register for notifications, and thus the registration was still active.
