### PR TITLE
Add NSPhotoLibraryUsageDescription to Info.plist

### DIFF
--- a/Multisig/Info.plist
+++ b/Multisig/Info.plist
@@ -201,6 +201,8 @@
 	</array>
 	<key>WALLETCONNECT_BRIDGE_URL</key>
 	<string>$(WALLETCONNECT_BRIDGE_URL)</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The app needs access to the photo library if you need to share your screenshot with our support team.</string>
 	<key>DESKTOP_PAIRING_EXPERIMENTAL_ENABLED</key>
 	<string>$(DESKTOP_PAIRING_EXPERIMENTAL_ENABLED)</string>
 </dict>


### PR DESCRIPTION
Changes proposed in this pull request:
- Add NSPhotoLibraryUsageDescription to Info.plist to allow uploads to Testflight and the apps tore
-
-
