### PR TITLE
gh-1636 Added models for json rpc and eth rpc subset

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -201,6 +201,9 @@
 		0A478D5825B876AF0038363E /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A478D5625B876AF0038363E /* ButtonTableViewCell.swift */; };
 		0A478D5925B876AF0038363E /* ButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A478D5725B876AF0038363E /* ButtonTableViewCell.xib */; };
 		0A4F44542754DE3D00423ABB /* GetDelegateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */; };
+		0A513A952768974900F07D5A /* EthRpc1Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A513A942768974900F07D5A /* EthRpc1Types.swift */; };
+		0A513A9727689CA000F07D5A /* EthRpc1Requests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A513A9627689CA000F07D5A /* EthRpc1Requests.swift */; };
+		0A513A992768A1E400F07D5A /* JsonRpc2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A513A982768A1E400F07D5A /* JsonRpc2.swift */; };
 		0A5307162543110300E8A270 /* ConfirmTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5307152543110300E8A270 /* ConfirmTransactionRequest.swift */; };
 		0A530720254311C400E8A270 /* SafeTransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A53071F254311C400E8A270 /* SafeTransactionSigner.swift */; };
 		0A5307462543273F00E8A270 /* UIViewController+UINib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5307452543273F00E8A270 /* UIViewController+UINib.swift */; };
@@ -813,6 +816,9 @@
 		0A478D5625B876AF0038363E /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
 		0A478D5725B876AF0038363E /* ButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ButtonTableViewCell.xib; sourceTree = "<group>"; };
 		0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDelegateRequest.swift; sourceTree = "<group>"; };
+		0A513A942768974900F07D5A /* EthRpc1Types.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthRpc1Types.swift; sourceTree = "<group>"; };
+		0A513A9627689CA000F07D5A /* EthRpc1Requests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthRpc1Requests.swift; sourceTree = "<group>"; };
+		0A513A982768A1E400F07D5A /* JsonRpc2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonRpc2.swift; sourceTree = "<group>"; };
 		0A5307152543110300E8A270 /* ConfirmTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmTransactionRequest.swift; sourceTree = "<group>"; };
 		0A53071F254311C400E8A270 /* SafeTransactionSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeTransactionSigner.swift; sourceTree = "<group>"; };
 		0A5307452543273F00E8A270 /* UIViewController+UINib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+UINib.swift"; sourceTree = "<group>"; };
@@ -2258,6 +2264,16 @@
 			path = SeedPhraseViewController;
 			sourceTree = "<group>";
 		};
+		0ADE3F25276765E5009E79EF /* Ethereum */ = {
+			isa = PBXGroup;
+			children = (
+				0A513A942768974900F07D5A /* EthRpc1Types.swift */,
+				0A513A9627689CA000F07D5A /* EthRpc1Requests.swift */,
+				0A513A982768A1E400F07D5A /* JsonRpc2.swift */,
+			);
+			path = Ethereum;
+			sourceTree = "<group>";
+		};
 		0AF1C90D2541B67200E28669 /* LoadableViewController */ = {
 			isa = PBXGroup;
 			children = (
@@ -2562,6 +2578,7 @@
 		5532D4DF2449A4C00067505A /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				0ADE3F25276765E5009E79EF /* Ethereum */,
 				5532D4B72449A17D0067505A /* Utils */,
 				0A9BC33824602E9500EB9C5D /* EthereumNodeService.swift */,
 				043ABD0924EF0C33008826D5 /* Safe Client Gateway Service */,
@@ -3328,6 +3345,7 @@
 				55F9B7A226D6665C003D1C68 /* LedgerPendingConfirmationViewController.swift in Sources */,
 				0A57C8E92587AECB00B7C019 /* EnterSafeAddressViewController.swift in Sources */,
 				0A616B9626AEEBB700FCEDB9 /* BoolString.swift in Sources */,
+				0A513A9727689CA000F07D5A /* EthRpc1Requests.swift in Sources */,
 				0A81E310246C062400425DEF /* Icons.swift in Sources */,
 				0AD062E62577AE7E0030810D /* TransactionDetailCellBuilder.swift in Sources */,
 				55413673265E493500796F91 /* AddOwnerKeyViewController.swift in Sources */,
@@ -3364,6 +3382,7 @@
 				048B3B0E25A5E7AB0005219B /* EditSafeNameViewController.swift in Sources */,
 				0AF2733D24DABAAF007E4012 /* AppDelegate+Messaging.swift in Sources */,
 				0ADD19C0265EA23200EB0F2B /* PrivateKeyViewController.swift in Sources */,
+				0A513A992768A1E400F07D5A /* JsonRpc2.swift in Sources */,
 				558835E7255AEA390014E8C7 /* InfoCell.swift in Sources */,
 				0AC2A3C726FB6802002CB26A /* CollectiblesUnsupportedViewController.swift in Sources */,
 				555312EB2506608D0008206B /* Base58.swift in Sources */,
@@ -3621,6 +3640,7 @@
 				55F91A9225BEABA100938475 /* EnterKeyOrSeedPhraseViewController.swift in Sources */,
 				04B4B5F725B754D600CFE24B /* AccountActionCompletedViewController.swift in Sources */,
 				0A5F4831254C56CE0069C98D /* AddSafeTableViewCell.swift in Sources */,
+				0A513A952768974900F07D5A /* EthRpc1Types.swift in Sources */,
 				0A5C2DCE25628277009808CB /* SafeInfoViewController.swift in Sources */,
 				0AC60C512549AF2200A63AE2 /* NoSafeBarView.swift in Sources */,
 				0A007124254B255C00A57CAF /* UIFont+Styles.swift in Sources */,

--- a/Multisig/Data/Services/Ethereum/EthRpc1Requests.swift
+++ b/Multisig/Data/Services/Ethereum/EthRpc1Requests.swift
@@ -1,0 +1,164 @@
+//
+//  EthRpc1Requests.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 14.12.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+extension EthRpc1 {
+    /// Returns the current price per gas in wei.
+    enum eth_gasPrice {
+        static func request() -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_gasPrice", params: nil)
+        }
+        /// No parameters
+        typealias Params = JsonRpc2.EmptyParams
+
+        /// Gas price
+        typealias Result = String
+    }
+
+    /// Executes a new message call immediately without creating a transaction on the block chain.
+    enum eth_call {
+        static func request(_ params: Params) -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_call", params: params)
+        }
+
+        /// Transaction. NOTE: `from` field MUST be present.
+        typealias Params = TransactionParams
+
+        /// Return data
+        typealias Result = String
+    }
+
+    /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+    enum eth_estimateGas {
+        static func request(_ params: Params) -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_estimateGas", params: params)
+        }
+
+        /// Transaction. NOTE: `from` field MUST be present.
+        typealias Params = TransactionParams
+        /// Gas used
+        typealias Result = String
+    }
+
+    /// Submits a raw transaction.
+    enum eth_sendRawTransaction {
+        static func request(_ params: Params) -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_sendRawTransaction", params: params)
+        }
+
+        /// Transaction as bytes
+        struct Params {
+            var transaction: String
+        }
+
+        /// Transaction hash, or the zero hash if the transaction is not yet available
+        typealias Result = String
+    }
+
+    /// Returns the receipt of a transaction by transaction hash.
+    enum eth_getTransactionReceipt {
+        static func request(_ params: Params) -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_getTransactionReceipt", params: params)
+        }
+
+        /// Transaction hash bytes
+        struct Params {
+            var transactionHash: String
+        }
+
+        /// Receipt Information or null if transaction not found
+        typealias Result = ReceiptInfo?
+    }
+
+    /// Returns the balance of the account of given address.
+    enum eth_getBalance {
+        static func request(_ params: Params) -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_getBalance", params: params)
+        }
+
+        typealias Params = AccountParams
+        /// Balance
+        typealias Result = String
+    }
+
+    /// Returns the number of transactions sent from an address.
+    enum eth_getTransactionCount {
+        static func request(_ params: Params) -> JsonRpc2.Request<Params> {
+            .init(jsonrpc: "2.0", method: "eth_getTransactionCount", params: params)
+        }
+
+        typealias Params = AccountParams
+        /// Transaction count
+        #warning("TODO: double-check because EIP-1474 and the OpenRPC spec differ types: String vs [String]")
+        typealias Result = String
+    }
+
+    /// Parameters for the requests for state of an account
+    struct AccountParams {
+        /// account address
+        var address: String
+        /// block number or tag ("earliest", "latest", "pending")
+        var block: String
+    }
+
+    /// Parameters for the requests related to transactions
+    struct TransactionParams {
+        var transaction: Transaction
+    }
+}
+
+extension EthRpc1.eth_sendRawTransaction.Params: Codable {
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        transaction = try container.decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(transaction)
+    }
+}
+
+extension EthRpc1.eth_getTransactionReceipt.Params: Codable {
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        transactionHash = try container.decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(transactionHash)
+    }
+}
+
+extension EthRpc1.AccountParams: Codable {
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        address = try container.decode(String.self)
+        block = try container.decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(address)
+        try container.encode(block)
+    }
+}
+
+extension EthRpc1.TransactionParams: Codable {
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        transaction = try container.decode(EthRpc1.Transaction.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(transaction)
+    }
+}

--- a/Multisig/Data/Services/Ethereum/EthRpc1Types.swift
+++ b/Multisig/Data/Services/Ethereum/EthRpc1Types.swift
@@ -13,7 +13,7 @@ import Foundation
 /// See more:
 ///   - https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json
 ///   - https://eips.ethereum.org/EIPS/eip-1474
-enum EthRpc1 { 
+enum EthRpc1 {
     enum Transaction: Codable {
         case legacy(TransactionLegacy)
         case eip2930(Transaction2930)
@@ -24,8 +24,13 @@ enum EthRpc1 {
         init(from decoder: Decoder) throws {
             enum Key: String, CodingKey { case type }
             let container = try decoder.container(keyedBy: Key.self)
-            let type = try container.decode(String.self, forKey: .type)
-            guard let byte = Data(ethHex: type).bytes.first else {
+            var type = try container.decode(String.self, forKey: .type)
+
+            if type.hasPrefix("0x") {
+                type.removeFirst(2)
+            }
+
+            guard let byte = UInt8(type, radix: 16) else {
                 throw DecodingError.dataCorrupted(
                     DecodingError.Context(
                         codingPath: decoder.codingPath,

--- a/Multisig/Data/Services/Ethereum/EthRpc1Types.swift
+++ b/Multisig/Data/Services/Ethereum/EthRpc1Types.swift
@@ -1,0 +1,282 @@
+//
+//  EthRpc1Types.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 14.12.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// Namespace for the types defined in the Ethereum JSON-RPC 1.0 specification
+///
+/// See more:
+///   - https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json
+///   - https://eips.ethereum.org/EIPS/eip-1474
+enum EthRpc1 { 
+    enum Transaction: Codable {
+        case legacy(TransactionLegacy)
+        case eip2930(Transaction2930)
+        case eip1559(Transaction1559)
+        /// not known type
+        case unknown
+
+        init(from decoder: Decoder) throws {
+            enum Key: String, CodingKey { case type }
+            let container = try decoder.container(keyedBy: Key.self)
+            let type = try container.decode(String.self, forKey: .type)
+            guard let byte = Data(ethHex: type).bytes.first else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Invalid transaction `type` value: \(type)")
+                )
+            }
+
+            // Learn more:
+            // https://eips.ethereum.org/EIPS/eip-1559
+            // https://eips.ethereum.org/EIPS/eip-2930
+            // https://eips.ethereum.org/EIPS/eip-2718
+
+            // Type of a transaction with access list and chain Id. Defined in EIP-2930
+            let EIP_2930_TYPE: UInt8 = 0x01
+
+            // Type of a transaction with priority fee. Defined in EIP-1559
+            let EIP_1559_TYPE: UInt8 = 0x02
+
+            // Legacy transaction type value. Defined in EIP-2718
+            let LEGACY_RANGE_TYPE: ClosedRange<UInt8> = (0xc0...0xfe)
+
+            // All possible values for the 'type' according to EIP-2718
+            let EIP_2718_RANGE_TYPE: ClosedRange<UInt8> = (0x00...0x7f)
+
+            // Reserved value for the 'type' according to EIP-2718
+            let EIP_2718_RESERVED_TYPE: UInt8 = 0xff
+
+            switch byte {
+            case EIP_2930_TYPE:
+                self = try .eip2930(.init(from: decoder))
+            case EIP_1559_TYPE:
+                self = try .eip1559(.init(from: decoder))
+            case LEGACY_RANGE_TYPE:
+                self = try .legacy(.init(from: decoder))
+            case EIP_2718_RANGE_TYPE:
+                // backwards compatibility:
+                // EIP-2718 transaction but we don't know it's type
+                fallthrough
+            case EIP_2718_RESERVED_TYPE:
+                fallthrough
+            default:
+                self = .unknown
+            }
+        }
+    }
+
+    struct TransactionLegacy: Codable {
+        /// type according to EIP-2718
+        ///
+        /// Must be in range [0xc0, 0xfe]
+        var type: String
+
+        var nonce: String
+
+        /// to address
+        var to: String?
+
+        /// gas limit
+        var gas: String
+
+        var value: String
+
+        /// input data
+        var input: String
+
+        /// The gas price willing to be paid by the sender in wei
+        var gasPrice: String
+
+        /// Chain ID that this transaction is valid on.
+        var chainId: String?
+
+        /// from address
+        var from: String?
+
+        var blockHash: String?
+
+        var blockNumber: String?
+
+        /// Transaction hash
+        var hash: String?
+
+        var transactionIndex: String?
+
+        /// Signature 'v' component
+        var v: String?
+
+        /// Signature 'r' component
+        var r: String?
+
+        /// Signature 's' component
+        var s: String?
+    }
+
+    /// EIP-2930 transaction.
+    struct Transaction2930: Codable {
+        /// type according to EIP-2718
+        ///
+        /// Must be 0x01 per specification
+        var type: String
+
+        var nonce: String
+
+        /// to address
+        var to: String?
+
+        /// gas limit
+        var gas: String
+
+        var value: String
+
+        /// input data
+        var input: String
+
+        /// The gas price willing to be paid by the sender in wei
+        var gasPrice: String
+
+        /// EIP-2930 access list
+        var accessList: [AccessListEntry]
+
+        /// Chain ID that this transaction is valid on.
+        var chainId: String
+
+        /// from address
+        var from: String?
+
+        var blockHash: String?
+
+        var blockNumber: String?
+
+        /// Transaction hash
+        var hash: String?
+
+        var transactionIndex: String?
+
+        /// The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
+        var yParity: String?
+
+        /// Signature 'r' component
+        var r: String?
+
+        /// Signature 's' component
+        var s: String?
+    }
+
+    /// EIP-1559 transaction.
+    struct Transaction1559: Codable {
+        /// type according to EIP-2718
+        ///
+        /// Must be 0x02 per specification
+        var type: String
+
+        var nonce: String
+
+        /// to address
+        var to: String?
+
+        /// gas limit
+        var gas: String
+
+        var value: String
+
+        /// input data
+        var input: String
+
+        /// Maximum fee per gas the sender is willing to pay to miners in wei
+        var maxPriorityFeePerGas: String
+
+        /// The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
+        var maxFeePerGas: String
+
+        /// EIP-2930 access list
+        var accessList: [AccessListEntry]
+
+        /// Chain ID that this transaction is valid on.
+        var chainId: String
+
+        /// from address
+        var from: String?
+
+        var blockHash: String?
+
+        var blockNumber: String?
+
+        /// Transaction hash
+        var hash: String?
+
+        var transactionIndex: String?
+
+        /// The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
+        var yParity: String?
+
+        /// Signature 'r' component
+        var r: String?
+
+        /// Signature 's' component
+        var s: String?
+    }
+
+    struct Log: Codable {
+        var removed: Bool?
+        var logIndex: String?
+        var transactionIndex: String?
+        var transactionHash: String?
+        var blockHash: String?
+        var blockNumber: String?
+        var address: String?
+        var data: String?
+        var topics: [String]?
+    }
+
+    struct ReceiptInfo: Codable {
+        var transactionHash: String
+
+        var transactionIndex: String
+
+        var blockHash: String
+
+        var blockNumber: String
+
+        var from: String
+
+        /// Address of the receiver or null in a contract creation transaction.
+        var to: String?
+
+        /// The sum of gas used by this transaction and all preceding transactions in the same block.
+        var cumulativeGasUsed: String
+
+        /// The amount of gas used for this specific transaction alone.
+        var gasUsed: String
+
+        /// The contract address created, if the transaction was a contract creation, otherwise null.
+        var contractAddress: String?
+
+        var logs: [Log]
+
+        var logsBloom: String
+
+        /// The post-transaction state root. Only specified for transactions included before the Byzantium upgrade.
+        var root: String?
+
+        /// Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade.
+        var status: String?
+
+        /// The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
+        var effectiveGasPrice: String
+    }
+
+    /// Access list entry
+    struct AccessListEntry: Codable {
+        var address: String?
+        var storageKeys: [String]?
+    }
+}
+

--- a/Multisig/Data/Services/Ethereum/JsonRpc2.swift
+++ b/Multisig/Data/Services/Ethereum/JsonRpc2.swift
@@ -1,0 +1,172 @@
+//
+//  JsonRpc2.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 14.12.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// Namespace for the types defined by the JSON-RPC 2.0 specification
+///
+/// See more: https://www.jsonrpc.org/specification
+enum JsonRpc2 {
+
+    /// A rpc call is represented by sending a Request object to a Server
+    struct Request<Params: Codable>: Codable {
+        /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
+        var jsonrpc: String
+
+        /// A String containing the name of the method to be invoked. Method names that begin with the word rpc followed by a period character (U+002E or ASCII 46) are reserved for rpc-internal methods and extensions and MUST NOT be used for anything else.
+        var method: String
+
+        /// A Structured value that holds the parameter values to be used during the invocation of the method. This member MAY be omitted.
+        ///
+        /// Example of the named params with Codable:
+        /// ```
+        /// struct MyNamedParams: Codable {
+        ///     var param1: String
+        ///     var param2: Int
+        /// }
+        /// ```
+        ///
+        /// Example of the positional params (array of different types) with Codable:
+        /// ```
+        /// struct MyPositionalParams: Codable {
+        ///     var param1: String
+        ///     var param2: Int
+        ///
+        ///     init(from decoder: Decoder) throws {
+        ///         var container = try decoder.unkeyedContainer()
+        ///         param1 = try container.decode(String.self)
+        ///         param2 = try container.decode(Int.self)
+        ///     }
+        ///
+        ///     func encode(to encoder: Encoder) throws {
+        ///         var container = encoder.unkeyedContainer()
+        ///         try container.encode(param1)
+        ///         try container.encode(param2)
+        ///     }
+        /// }
+        /// ```
+        var params: Params?
+
+        /// An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts
+        /// The Server MUST reply with the same value in the Response object if included. This member is used to correlate the context between the two objects.
+        var id: Id?
+    }
+
+    struct EmptyParams: Codable {
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode([String]())
+        }
+    }
+
+
+    /// Request identifier, it is a String, Number (integer or fractional), or NULL.
+    enum Id: Codable {
+        case string(String)
+        case int(Int)
+        case double(Double)
+        case null
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let string = (try? container.decode(String.self)) {
+                self = .string(string)
+            } else if let int = (try? container.decode(Int.self)) {
+                self = .int(int)
+            } else if let double = (try? container.decode(Double.self)) {
+                self = .double(double)
+            } else if container.decodeNil() {
+                self = .null
+            } else {
+                throw DecodingError.typeMismatch(
+                    Id.self,
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Unexpected Id type in the json rpc object")
+                )
+            }
+        }
+    }
+
+    /// When a rpc call is made, the Server MUST reply with a Response, except for in the case of Notifications. The Response is expressed as a single JSON Object
+    struct Response<Success: Codable, ErrorData: Codable>: Codable {
+        /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0"
+        var jsonrpc: String
+
+        /// Represents 2 mutually exclusive fields from the spec: result and error.
+        ///
+        /// `result` is present on success:
+        /// This member is REQUIRED on success.
+        /// This member MUST NOT exist if there was an error invoking the method.
+        /// The value of this member is determined by the method invoked on the Server.
+        ///
+        /// `error` is present on failure:
+        /// This member is REQUIRED on error.
+        /// This member MUST NOT exist if there was no error triggered during invocation.
+        /// The value for this member MUST be an Object as defined in section 5.1.
+        var result: Result<Success, Error<ErrorData>>
+
+        /// This member is REQUIRED.
+        /// It MUST be the same as the value of the id member in the Request Object.
+        /// If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
+        var id: Id
+    }
+
+    /// When a rpc call encounters an error, the Response Object MUST contain the error member with a value that is a Object
+    struct Error<ErrorData: Codable>: Swift.Error, Codable {
+        ///  A Number that indicates the error type that occurred.
+        ///  This MUST be an integer.
+        var code: Int
+
+        /// A String providing a short description of the error.
+        /// The message SHOULD be limited to a concise single sentence.
+        var message: String
+
+        /// A Primitive or Structured value that contains additional information about the error.
+        /// This may be omitted.
+        /// The value of this member is defined by the Server (e.g. detailed error information, nested errors etc.).
+        var data: ErrorData?
+    }
+}
+
+extension JsonRpc2.Response {
+    enum Keys: String, CodingKey {
+        case jsonrpc, result, error, id
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Keys.self)
+        jsonrpc = try container.decode(String.self, forKey: .jsonrpc)
+        id = try container.decode(JsonRpc2.Id.self, forKey: .id)
+
+        if let result = try container.decodeIfPresent(Success.self, forKey: .result) {
+            self.result = .success(result)
+        } else if let error = try container.decodeIfPresent(JsonRpc2.Error<ErrorData>.self, forKey: .error) {
+            self.result = .failure(error)
+        } else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expecting either `result` or `error` field present in the response, but none found.")
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Keys.self)
+        try container.encode(jsonrpc, forKey: .jsonrpc)
+        try container.encode(id, forKey: .id)
+
+        switch result {
+        case .success(let result):
+            try container.encode(result, forKey: .result)
+        case .failure(let error):
+            try container.encode(error, forKey: .error)
+        }
+    }
+}

--- a/Multisig/Data/Services/Ethereum/JsonRpc2.swift
+++ b/Multisig/Data/Services/Ethereum/JsonRpc2.swift
@@ -12,7 +12,6 @@ import Foundation
 ///
 /// See more: https://www.jsonrpc.org/specification
 enum JsonRpc2 {
-
     /// A rpc call is represented by sending a Request object to a Server
     struct Request<Params: Codable>: Codable {
         /// A String specifying the version of the JSON-RPC protocol. MUST be exactly "2.0".
@@ -63,7 +62,6 @@ enum JsonRpc2 {
             try container.encode([String]())
         }
     }
-
 
     /// Request identifier, it is a String, Number (integer or fractional), or NULL.
     enum Id: Codable {


### PR DESCRIPTION
Handles #1636

Changes proposed in this pull request:
- JSON RPC v2 models
- Ethereum JSON RPC v1 models and subset of requests related to transaction execution implementation:
  - eth_gasPrice
  - eth_call
  - eth_estimateGas
  - eth_sendRawTransaction
  - eth_getTransactionReceipt
  - eth_getBalance
  - eth_getTransactionCount
