### PR TITLE
gh-1477 Added API tests

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		0A478D5825B876AF0038363E /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A478D5625B876AF0038363E /* ButtonTableViewCell.swift */; };
 		0A478D5925B876AF0038363E /* ButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A478D5725B876AF0038363E /* ButtonTableViewCell.xib */; };
 		0A4F44542754DE3D00423ABB /* GetDelegateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */; };
+		0A513A9D2768EBC900F07D5A /* DelegateKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A513A9C2768EBC900F07D5A /* DelegateKeyTests.swift */; };
 		0A5307162543110300E8A270 /* ConfirmTransactionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5307152543110300E8A270 /* ConfirmTransactionRequest.swift */; };
 		0A530720254311C400E8A270 /* SafeTransactionSigner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A53071F254311C400E8A270 /* SafeTransactionSigner.swift */; };
 		0A5307462543273F00E8A270 /* UIViewController+UINib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5307452543273F00E8A270 /* UIViewController+UINib.swift */; };
@@ -825,6 +826,7 @@
 		0A478D5625B876AF0038363E /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
 		0A478D5725B876AF0038363E /* ButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ButtonTableViewCell.xib; sourceTree = "<group>"; };
 		0A4F44532754DE3D00423ABB /* GetDelegateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDelegateRequest.swift; sourceTree = "<group>"; };
+		0A513A9C2768EBC900F07D5A /* DelegateKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DelegateKeyTests.swift; sourceTree = "<group>"; };
 		0A5307152543110300E8A270 /* ConfirmTransactionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmTransactionRequest.swift; sourceTree = "<group>"; };
 		0A53071F254311C400E8A270 /* SafeTransactionSigner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeTransactionSigner.swift; sourceTree = "<group>"; };
 		0A5307452543273F00E8A270 /* UIViewController+UINib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+UINib.swift"; sourceTree = "<group>"; };
@@ -2168,6 +2170,7 @@
 				0A3DFF002667D7DA00B45770 /* CoreData */,
 				0A64313F247ED1AA006FD30A /* MultisigIntegrationTests.xctestplan */,
 				0A802B8F24E581A50001790F /* SafeClientGatewayServiceIntegrationTests.swift */,
+				0A513A9C2768EBC900F07D5A /* DelegateKeyTests.swift */,
 				5532D4D02449A1E40067505A /* MockLogger.swift */,
 				0A9BC34D2460567200EB9C5D /* ENSIntegrationTests.swift */,
 				0A9BC3572460581500EB9C5D /* Info.plist */,
@@ -3739,6 +3742,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A513A9D2768EBC900F07D5A /* DelegateKeyTests.swift in Sources */,
 				0A61E8422670E474009D68A4 /* CellTestViewController.swift in Sources */,
 				0ADFADA3267B496F007ACD65 /* BalancesTableViewControllerTests.swift in Sources */,
 				0A9BC35D2460581A00EB9C5D /* ENSIntegrationTests.swift in Sources */,

--- a/Multisig/Data/Services/Safe Client Gateway Service/DeleteDelegateKeyRequest.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/DeleteDelegateKeyRequest.swift
@@ -9,36 +9,37 @@
 import Foundation
 
 struct DeleteDelegateKeyRequest: JSONRequest {
-    var httpMethod: String { "DELETE" }
-    var urlPath: String { "/v1/chains/\(chainId)/delegates/" }
-
-    typealias ResponseType = EmptyResponse
-
-    struct EmptyResponse: Decodable { }
-
-    var safe: String?
+    let chainId: String
     var delegate: String
     var delegator: String
     var signature: String
-    let chainId: String
+
+    var httpMethod: String { "DELETE" }
+
+    var urlPath: String { "/v1/chains/\(chainId)/delegates/\(delegate)" }
+
+    typealias ResponseType = EmptyResponse
+    struct EmptyResponse: Decodable { }
+
+    enum CodingKeys: String, CodingKey {
+        case delegate, delegator, signature
+    }
 }
 
 extension SafeClientGatewayService {
 
     @discardableResult
     func asyncDeleteDelegate(
-        safe: Address?,
         owner: Address,
         delegate: Address,
         signature: String,
         chainId: String,
         completion: @escaping (Result<DeleteDelegateKeyRequest.ResponseType, Error>) -> Void
     ) -> URLSessionTask? {
-        asyncExecute(request: DeleteDelegateKeyRequest(safe: safe?.checksummed,
+        asyncExecute(request: DeleteDelegateKeyRequest(chainId: chainId,
                                                        delegate: delegate.checksummed,
                                                        delegator: owner.checksummed,
-                                                       signature: signature,
-                                                       chainId: chainId),
+                                                       signature: signature),
                      completion: completion)
     }
 }

--- a/Multisig/Data/Services/Safe Client Gateway Service/DeleteDelegateKeyRequest.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/DeleteDelegateKeyRequest.swift
@@ -16,6 +16,7 @@ struct DeleteDelegateKeyRequest: JSONRequest {
 
     struct EmptyResponse: Decodable { }
 
+    var safe: String?
     var delegate: String
     var delegator: String
     var signature: String
@@ -26,13 +27,15 @@ extension SafeClientGatewayService {
 
     @discardableResult
     func asyncDeleteDelegate(
+        safe: Address?,
         owner: Address,
         delegate: Address,
         signature: String,
         chainId: String,
         completion: @escaping (Result<DeleteDelegateKeyRequest.ResponseType, Error>) -> Void
     ) -> URLSessionTask? {
-        asyncExecute(request: DeleteDelegateKeyRequest(delegate: delegate.checksummed,
+        asyncExecute(request: DeleteDelegateKeyRequest(safe: safe?.checksummed,
+                                                       delegate: delegate.checksummed,
                                                        delegator: owner.checksummed,
                                                        signature: signature,
                                                        chainId: chainId),

--- a/Multisig/Data/Services/Safe Client Gateway Service/GetDelegateRequest.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/GetDelegateRequest.swift
@@ -18,11 +18,21 @@ struct GetDelegateRequest: JSONRequest {
     var httpMethod: String { "GET" }
     var urlPath: String { "/v1/chains/\(chainId)/delegates/" }
 
+    var query: String? {
+        [
+            safe.map { "safe=" + $0 },
+            delegate.map { "delegate=" + $0 },
+            delegator.map { "delegator=" + $0 },
+            label.map { "label=" + $0 }
+        ].compactMap { $0 }.joined(separator: "&")
+    }
+
     typealias ResponseType = Page<SCGModels.KeyDelegate>
 }
 
 extension SafeClientGatewayService {
-    func asyncCreateDelegate(
+    @discardableResult
+    func asyncGetDelegate(
         chainId: String,
         safe: Address? = nil,
         delegator: Address? = nil,

--- a/Multisig/Data/Services/Safe Client Gateway Service/SCGModels.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/SCGModels.swift
@@ -610,7 +610,7 @@ extension SCGModels {
     }
 
     struct KeyDelegate: Codable {
-        var safe: AddressString
+        var safe: AddressString?
         var delegate: AddressString
         var delegator: AddressString
         var label: String

--- a/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
@@ -226,8 +226,7 @@ class DelegateKeyController {
         Chain.all.forEach { chain in
             // trigger request
             group.enter()
-            clientGatewayService.asyncDeleteDelegate(safe: nil,
-                                                     owner: keyInfo.address,
+            clientGatewayService.asyncDeleteDelegate(owner: keyInfo.address,
                                                      delegate: delegateAddress,
                                                      signature: signature,
                                                      chainId: chain.id!) { result in

--- a/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
@@ -226,7 +226,8 @@ class DelegateKeyController {
         Chain.all.forEach { chain in
             // trigger request
             group.enter()
-            clientGatewayService.asyncDeleteDelegate(owner: keyInfo.address,
+            clientGatewayService.asyncDeleteDelegate(safe: nil,
+                                                     owner: keyInfo.address,
                                                      delegate: delegateAddress,
                                                      signature: signature,
                                                      chainId: chain.id!) { result in

--- a/MultisigIntegrationTests/DelegateKeyTests.swift
+++ b/MultisigIntegrationTests/DelegateKeyTests.swift
@@ -1,0 +1,192 @@
+//
+//  DelegateKeyTests.swift
+//  MultisigIntegrationTests
+//
+//  Created by Dmitry Bespalov on 14.12.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+import Web3
+
+class DelegateKeyTests: XCTestCase {
+
+    var delegatorKey: PrivateKey!
+    var delegateKey: PrivateKey!
+    var chainId: String = "4"
+
+    var clientGateway = App.shared.clientGatewayService
+
+    func loadKeys() throws {
+        // delegator key
+
+        //  generate new one
+
+//        let delegatorSeed = Data.randomBytes(length: 16)!
+//        let delegatorMnemonic = BIP39.generateMnemonicsFromEntropy(entropy: delegatorSeed)!
+//        delegatorKey = try PrivateKey(mnemonic: delegatorMnemonic, pathIndex: 0)
+//        print("Created DELEGATOR key: \(delegatorKey.address.checksummed)\nMnemonic: \(delegatorMnemonic)\nPrivate key: \(delegatorKey.keyData.toHexStringWithPrefix())")
+
+        // or import from mnemonic:
+
+        delegatorKey = try PrivateKey(mnemonic: "obvious cart elephant coach move gain alpha mask size seed few powder", pathIndex: 0)
+        print("Loaded DELEGATOR key from mnemonic: \(delegatorKey.address.checksummed)")
+
+        // or import from private key
+
+//      delegatorKey = try PrivateKey(data: Data(hex: "0x642ee134fdd0566100f3adf50e9ee33510947728da93669f487930f1b116b13e"))
+//        print("Loaded DELEGATOR key from private key: \(delegatorKey.address.checksummed)")
+
+        // delegate key
+
+        // generate new one
+
+//        let delegateSeed = Data.randomBytes(length: 16)!
+//        let delegateMnemonic = BIP39.generateMnemonicsFromEntropy(entropy: delegateSeed)!
+//        delegateKey = try PrivateKey(mnemonic: delegateMnemonic, pathIndex: 0)
+//        print("Created DELEGATE key: \(delegateKey.address.checksummed)\nMnemonic: \(delegateMnemonic)\nPrivate key: \(delegateKey.keyData.toHexStringWithPrefix())")
+
+        // or load delegate key from mnemonic:
+
+        delegateKey = try PrivateKey(mnemonic: "cricket tube parade unlock protect rib soccer reduce enemy educate special summer", pathIndex: 0)
+        print("Loaded DELEGATE key from mnemonic: \(delegateKey.address.checksummed)")
+
+        // or load delegate key from private key:
+
+//        delegateKey = try PrivateKey(data: Data(hex: "0x22d50064b4ef2a5c9ad84c234403c000b2302367a649e77f223cc3815da2fb73"))
+//        print("Loaded DELEGATE key from private key: \(delegateKey.address.checksummed)")
+    }
+
+    func testGenKeys() throws {
+        try loadKeys()
+    }
+
+    func delegateMessageSignature(by signer: PrivateKey) throws -> Data {
+        // compose the 'delegating' message
+        let timestamp = Int(Date().timeIntervalSince1970)
+        print("Timestamp: \(timestamp)")
+
+        let timestamp_div_3600 = timestamp / 3600
+        print("Timestamp / 3600: \(timestamp_div_3600)")
+
+        let message = delegateKey.address.checksummed + String(describing: timestamp_div_3600)
+        print("Message: \(message)")
+
+        let hash = EthHasher.hash(message)
+        print("Hash: \(hash.toHexStringWithPrefix())")
+
+        // sign it with DELEGATOR key:
+        let signature = try signer.sign(hash: hash)
+        print("Signature: \(signature.hexadecimal)")
+
+        return Data(hex: signature.hexadecimal)
+    }
+
+    func testCreateDelegate() throws {
+        try loadKeys()
+
+        let signature = try delegateMessageSignature(by: delegateKey)
+
+        // create delegate
+        let exp = expectation(description: "Async Create Delegate Request")
+
+        let label = "iOS Test Delegate Key"
+
+        clientGateway.asyncCreateDelegate(
+            safe: nil,
+            owner: delegatorKey.address,
+            delegate: delegateKey.address,
+            signature: signature,
+            label: label,
+            chainId: chainId
+        ) { result in
+            switch result {
+            case .success:
+                print("Created delegate")
+            case .failure(let error):
+                print("Failed to create delegate: \(error)")
+                XCTFail(error.localizedDescription)
+            }
+
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+
+    func testGetDelegates() throws {
+        try loadKeys()
+
+        // get delegates
+        let exp = expectation(description: "Async Get Delegate Request")
+        clientGateway.asyncGetDelegate(
+            chainId: chainId,
+            delegator: delegatorKey.address
+        ) { result in
+            switch result {
+            case .success(let resp):
+                print("Delegates: \(resp.results)")
+            case .failure(let error):
+                print("Failed to get delegates: \(error)")
+                XCTFail(error.localizedDescription)
+            }
+
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+
+    func testDeleteDelegateByDelegate() throws {
+        try loadKeys()
+
+        let signature = try delegateMessageSignature(by: delegateKey)
+
+        let exp = expectation(description: "Async Delete Delegate Request")
+
+        clientGateway.asyncDeleteDelegate(
+            safe: nil,
+            owner: delegatorKey.address,
+            delegate: delegateKey.address,
+            signature: signature.toHexStringWithPrefix(),
+            chainId: chainId
+        ) { result in
+            switch result {
+            case .success:
+                print("Deleted delegate")
+            case .failure(let error):
+                print("Failed to delete delegate: \(error)")
+                XCTFail(error.localizedDescription)
+            }
+
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+
+    func testDeleteDelegateByDelegator() throws {
+        try loadKeys()
+
+        let signature = try delegateMessageSignature(by: delegatorKey)
+
+        let exp = expectation(description: "Async Delete Delegate Request")
+
+        clientGateway.asyncDeleteDelegate(
+            safe: nil,
+            owner: delegatorKey.address,
+            delegate: delegateKey.address,
+            signature: signature.toHexStringWithPrefix(),
+            chainId: chainId
+        ) { result in
+            switch result {
+            case .success:
+                print("Deleted delegate")
+            case .failure(let error):
+                print("Failed to delete delegate: \(error)")
+                XCTFail(error.localizedDescription)
+            }
+
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+}

--- a/MultisigIntegrationTests/DelegateKeyTests.swift
+++ b/MultisigIntegrationTests/DelegateKeyTests.swift
@@ -144,7 +144,6 @@ class DelegateKeyTests: XCTestCase {
         let exp = expectation(description: "Async Delete Delegate Request")
 
         clientGateway.asyncDeleteDelegate(
-            safe: nil,
             owner: delegatorKey.address,
             delegate: delegateKey.address,
             signature: signature.toHexStringWithPrefix(),
@@ -171,7 +170,6 @@ class DelegateKeyTests: XCTestCase {
         let exp = expectation(description: "Async Delete Delegate Request")
 
         clientGateway.asyncDeleteDelegate(
-            safe: nil,
             owner: delegatorKey.address,
             delegate: delegateKey.address,
             signature: signature.toHexStringWithPrefix(),


### PR DESCRIPTION
Handles #1477 

Changes proposed in this pull request:
- Added api tests for creating, getting, and deleting a delegate key
- Deleting a delegate key fails (https://github.com/gnosis/safe-client-gateway/issues/741)
