### PR TITLE
gh-1636 Added models and http client for eth rpc

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		0A007124254B255C00A57CAF /* UIFont+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A007123254B255C00A57CAF /* UIFont+Styles.swift */; };
 		0A00712A254B379000A57CAF /* UIColor+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A007129254B379000A57CAF /* UIColor+Styles.swift */; };
 		0A01DCE2277099C100A87D7A /* Ethereum in Frameworks */ = {isa = PBXBuildFile; productRef = 0A01DCE1277099C100A87D7A /* Ethereum */; };
+		0A01DCE42770B0A100A87D7A /* TransactionIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A01DCE32770B0A100A87D7A /* TransactionIntegrationTests.swift */; };
 		0A096CBE2608D9370034E6BC /* NetworkStatusObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A096CBD2608D9370034E6BC /* NetworkStatusObserver.swift */; };
 		0A096CC32608F4750034E6BC /* SignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55967104256E92470097D3A2 /* SignerTests.swift */; };
 		0A096CC82608F49E0034E6BC /* RegisterNotificationTokenRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55967118256EB2120097D3A2 /* RegisterNotificationTokenRequestTests.swift */; };
@@ -774,6 +775,7 @@
 		0A007123254B255C00A57CAF /* UIFont+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Styles.swift"; sourceTree = "<group>"; };
 		0A007129254B379000A57CAF /* UIColor+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Styles.swift"; sourceTree = "<group>"; };
 		0A01DCE02770996E00A87D7A /* Ethereum */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Ethereum; path = Packages/Ethereum; sourceTree = "<group>"; };
+		0A01DCE32770B0A100A87D7A /* TransactionIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionIntegrationTests.swift; sourceTree = "<group>"; };
 		0A096CBD2608D9370034E6BC /* NetworkStatusObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusObserver.swift; sourceTree = "<group>"; };
 		0A0C607A255D83E80085C178 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
 		0A0EFC9C246EA6E100D3D8BF /* AdvancedAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAppSettings.swift; sourceTree = "<group>"; };
@@ -2193,6 +2195,7 @@
 				55CA3EBC250A24910080DF7F /* KeychainServiceIntegrationTests.swift */,
 				0A3DFEFD2667D3A700B45770 /* README.md */,
 				0A61E8432670E5FF009D68A4 /* UI Snapshot Tests */,
+				0A01DCE32770B0A100A87D7A /* TransactionIntegrationTests.swift */,
 			);
 			path = MultisigIntegrationTests;
 			sourceTree = "<group>";
@@ -3800,6 +3803,7 @@
 				0A109E2F268A240F00226708 /* ChainTests.swift in Sources */,
 				0A9BC35F246058F800EB9C5D /* MockLogger.swift in Sources */,
 				550A6182268A23A9002C02E1 /* SafeNetworkMigrationTests.swift in Sources */,
+				0A01DCE42770B0A100A87D7A /* TransactionIntegrationTests.swift in Sources */,
 				0A61E83E2670DED5009D68A4 /* BalanceTableViewCellTests.swift in Sources */,
 				0A3DFEF72667D1C000B45770 /* CoreDataTestCase.swift in Sources */,
 				0A802B9024E581A50001790F /* SafeClientGatewayServiceIntegrationTests.swift in Sources */,

--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		04FC26B625CABE2300CDA9A0 /* AdvancedSafeSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04FC26B425CABE2300CDA9A0 /* AdvancedSafeSettingsViewController.swift */; };
 		0A007124254B255C00A57CAF /* UIFont+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A007123254B255C00A57CAF /* UIFont+Styles.swift */; };
 		0A00712A254B379000A57CAF /* UIColor+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A007129254B379000A57CAF /* UIColor+Styles.swift */; };
+		0A01DCE2277099C100A87D7A /* Ethereum in Frameworks */ = {isa = PBXBuildFile; productRef = 0A01DCE1277099C100A87D7A /* Ethereum */; };
 		0A096CBE2608D9370034E6BC /* NetworkStatusObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A096CBD2608D9370034E6BC /* NetworkStatusObserver.swift */; };
 		0A096CC32608F4750034E6BC /* SignerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55967104256E92470097D3A2 /* SignerTests.swift */; };
 		0A096CC82608F49E0034E6BC /* RegisterNotificationTokenRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55967118256EB2120097D3A2 /* RegisterNotificationTokenRequestTests.swift */; };
@@ -772,6 +773,7 @@
 		04FC26B425CABE2300CDA9A0 /* AdvancedSafeSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedSafeSettingsViewController.swift; sourceTree = "<group>"; };
 		0A007123254B255C00A57CAF /* UIFont+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Styles.swift"; sourceTree = "<group>"; };
 		0A007129254B379000A57CAF /* UIColor+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Styles.swift"; sourceTree = "<group>"; };
+		0A01DCE02770996E00A87D7A /* Ethereum */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Ethereum; path = Packages/Ethereum; sourceTree = "<group>"; };
 		0A096CBD2608D9370034E6BC /* NetworkStatusObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStatusObserver.swift; sourceTree = "<group>"; };
 		0A0C607A255D83E80085C178 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
 		0A0EFC9C246EA6E100D3D8BF /* AdvancedAppSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdvancedAppSettings.swift; sourceTree = "<group>"; };
@@ -1279,6 +1281,7 @@
 				D80B5A13276B5FAD00D6E024 /* SkeletonView in Frameworks */,
 				0A3DAD9526270F4D00743E38 /* idn2.xcframework in Frameworks */,
 				93EE3F752760F49800111F17 /* Intercom in Frameworks */,
+				0A01DCE2277099C100A87D7A /* Ethereum in Frameworks */,
 				0ACCC6E52742991100EC79B9 /* Web3 in Frameworks */,
 				55888DFF260C4F6200940347 /* SwiftAccessPolicy in Frameworks */,
 				0463F5C326296924009C04FA /* FirebaseCrashlytics in Frameworks */,
@@ -2030,6 +2033,7 @@
 		0A93DD4A2445CC8A00688050 = {
 			isa = PBXGroup;
 			children = (
+				0A01DCE02770996E00A87D7A /* Ethereum */,
 				0A3FDAD726AEB07F006A7DC3 /* Shared */,
 				0A93DD552445CC8A00688050 /* Multisig */,
 				0A93DD6F2445CC8C00688050 /* MultisigTests */,
@@ -3031,6 +3035,7 @@
 				0ACCC6E42742991100EC79B9 /* Web3 */,
 				93EE3F742760F49800111F17 /* Intercom */,
 				D80B5A12276B5FAD00D6E024 /* SkeletonView */,
+				0A01DCE1277099C100A87D7A /* Ethereum */,
 			);
 			productName = Multisig;
 			productReference = 0A93DD532445CC8A00688050 /* Multisig_PROD.app */;
@@ -5239,6 +5244,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 0463F5BD26296924009C04FA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		0A01DCE1277099C100A87D7A /* Ethereum */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Ethereum;
 		};
 		0A29B5612666808A0060F06A /* FirebaseAnalyticsWithoutAdIdSupport */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,286 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "abseil",
+        "repositoryURL": "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+        "state": {
+          "branch": null,
+          "revision": "fffc3c2729be5747390ad02d5100291a0d9ad26a",
+          "version": "0.20200225.4"
+        }
+      },
+      {
+        "package": "BigInt",
+        "repositoryURL": "https://github.com/attaswift/BigInt.git",
+        "state": {
+          "branch": null,
+          "revision": "0ed110f7555c34ff468e72e1686e59721f2b0da6",
+          "version": "5.3.0"
+        }
+      },
+      {
+        "package": "BlockiesSwift",
+        "repositoryURL": "https://github.com/gnosis/BlockiesSwift.git",
+        "state": {
+          "branch": "0.1.2-gnosis",
+          "revision": "f97be34ba7e10ac9778ca45474bed34a77b29a47",
+          "version": null
+        }
+      },
+      {
+        "package": "BoringSSL-GRPC",
+        "repositoryURL": "https://github.com/firebase/boringssl-SwiftPM.git",
+        "state": {
+          "branch": null,
+          "revision": "734a8247442fde37df4364c21f6a0085b6a36728",
+          "version": "0.7.2"
+        }
+      },
+      {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "4b0565384d3c4c588af09e660535b2c7c9bf5b39",
+          "version": "1.4.2"
+        }
+      },
+      {
+        "package": "EthereumAddress",
+        "repositoryURL": "https://github.com/sche/EthereumAddress.git",
+        "state": {
+          "branch": "update-CryptoSwift-version",
+          "revision": "6726437315d1f50bc24adea258d04ede3d0f73cb",
+          "version": null
+        }
+      },
+      {
+        "package": "Firebase",
+        "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
+        "state": {
+          "branch": null,
+          "revision": "839cc6b0cd80b0b8bf81fe9bd82b743b25dc6446",
+          "version": "8.9.1"
+        }
+      },
+      {
+        "package": "GoogleAppMeasurement",
+        "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
+        "state": {
+          "branch": null,
+          "revision": "9b2f6aca5b4685c45f9f5481f19bee8e7982c538",
+          "version": "8.9.1"
+        }
+      },
+      {
+        "package": "GoogleDataTransport",
+        "repositoryURL": "https://github.com/google/GoogleDataTransport.git",
+        "state": {
+          "branch": null,
+          "revision": "15ccdfd25ac55b9239b82809531ff26605e7556e",
+          "version": "9.1.2"
+        }
+      },
+      {
+        "package": "GoogleUtilities",
+        "repositoryURL": "https://github.com/google/GoogleUtilities.git",
+        "state": {
+          "branch": null,
+          "revision": "797005ad8a1f0614063933e2fa010a5d13cb09d0",
+          "version": "7.6.0"
+        }
+      },
+      {
+        "package": "gRPC",
+        "repositoryURL": "https://github.com/firebase/grpc-SwiftPM.git",
+        "state": {
+          "branch": null,
+          "revision": "fb405dd2c7901485f7e158b24e3a0a47e4efd8b5",
+          "version": "1.28.4"
+        }
+      },
+      {
+        "package": "GTMSessionFetcher",
+        "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
+        "state": {
+          "branch": null,
+          "revision": "bc6a19702ac76ac4e488b68148710eb815f9bc56",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "package": "Intercom",
+        "repositoryURL": "https://github.com/intercom/intercom-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "3a87d776c955e5b556295572fa7f0a24b0358365",
+          "version": "10.3.5"
+        }
+      },
+      {
+        "package": "Kingfisher",
+        "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
+        "state": {
+          "branch": null,
+          "revision": "318e319998bf555c3e914d5c3adb6da05af86a32",
+          "version": "7.1.1"
+        }
+      },
+      {
+        "package": "leveldb",
+        "repositoryURL": "https://github.com/firebase/leveldb.git",
+        "state": {
+          "branch": null,
+          "revision": "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+          "version": "1.22.2"
+        }
+      },
+      {
+        "package": "nanopb",
+        "repositoryURL": "https://github.com/firebase/nanopb.git",
+        "state": {
+          "branch": null,
+          "revision": "7ee9ef9f627d85cbe1b8c4f49a3ed26eed216c77",
+          "version": "2.30908.0"
+        }
+      },
+      {
+        "package": "PromiseKit",
+        "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
+        "state": {
+          "branch": null,
+          "revision": "93c8d41ce96ed78f36c3948be396d76f3ca3de1b",
+          "version": "6.16.2"
+        }
+      },
+      {
+        "package": "Promises",
+        "repositoryURL": "https://github.com/google/promises.git",
+        "state": {
+          "branch": null,
+          "revision": "611337c330350c9c1823ad6d671e7f936af5ee13",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "UnstoppableDomainsResolution",
+        "repositoryURL": "https://github.com/sche/resolution-swift.git",
+        "state": {
+          "branch": "update-deps",
+          "revision": "9da1a31c88a867a70555311143fed14b9fd88f5c",
+          "version": null
+        }
+      },
+      {
+        "package": "secp256k1",
+        "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "823281fe9def21b384099b72a9a53ca988317b20",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "package": "SkeletonView",
+        "repositoryURL": "https://github.com/Juanpe/SkeletonView.git",
+        "state": {
+          "branch": null,
+          "revision": "a9c22f502a4d938bd3fb6f17fe4d6633c423085a",
+          "version": "1.26.0"
+        }
+      },
+      {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
+        "state": {
+          "branch": null,
+          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "package": "swift-nio-zlib-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
+        "state": {
+          "branch": null,
+          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "package": "SwiftProtobuf",
+        "repositoryURL": "https://github.com/apple/swift-protobuf.git",
+        "state": {
+          "branch": null,
+          "revision": "7e2c5f3cbbeea68e004915e3a8961e20bd11d824",
+          "version": "1.18.0"
+        }
+      },
+      {
+        "package": "SnapshotTesting",
+        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
+        "state": {
+          "branch": null,
+          "revision": "f8a9c997c3c1dab4e216a8ec9014e23144cbab37",
+          "version": "1.9.0"
+        }
+      },
+      {
+        "package": "SwiftAccessPolicy",
+        "repositoryURL": "https://github.com/gnosis/SwiftAccessPolicy.git",
+        "state": {
+          "branch": "main",
+          "revision": "3a1972c0feec8fabc4dd500f04c2b833f20bef12",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftCryptoTokenFormatter",
+        "repositoryURL": "https://github.com/gnosis/SwiftCryptoTokenFormatter.git",
+        "state": {
+          "branch": null,
+          "revision": "6f605fd7bd61327a6006919e28bf3f0632d1c556",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "TrustKit",
+        "repositoryURL": "https://github.com/datatheorem/TrustKit.git",
+        "state": {
+          "branch": null,
+          "revision": "3c953558d61fdd9b136d981764e3242bd92b2648",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "package": "Version",
+        "repositoryURL": "https://github.com/mxcl/Version.git",
+        "state": {
+          "branch": null,
+          "revision": "1fe824b80d89201652e7eca7c9252269a1d85e25",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "package": "WalletConnectSwift",
+        "repositoryURL": "https://github.com/WalletConnect/WalletConnectSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "f951da68a32666712e8c80ba0c77e9df5dce9fd6",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "package": "Web3",
+        "repositoryURL": "https://github.com/gnosis/Web3.swift.git",
+        "state": {
+          "branch": "0.5.4",
+          "revision": "182ff667d6bceccafa3d3aa64ab64f2585001b99",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/MultisigIntegrationTests/TransactionIntegrationTests.swift
+++ b/MultisigIntegrationTests/TransactionIntegrationTests.swift
@@ -1,0 +1,75 @@
+//
+//  TransactionIntegrationTests.swift
+//  MultisigIntegrationTests
+//
+//  Created by Dmitry Bespalov on 20.12.21.
+//  Copyright © 2021 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+
+class TransactionIntegrationTests: XCTestCase {
+    // execute tx
+        // with a private key
+        // with a ledger key
+        // with a WC key
+
+        // using eth_sign
+        // using eth_personalSign
+        // using eth_signTypedData (v1, v2, v3, v4)?
+
+        // with enough confirmations
+        // with not enough confirmations
+
+        // gas estimation from chain
+        // gas estimation from gas station
+
+        // from CGW transaction details
+        // from WC transaction details
+
+        // safe implementation version
+            // 0.0.1
+            // 0.0.2
+            // 1.0.0
+            // 1.1.1
+            // 1.3.0
+
+        // with operation
+            // call
+            // delegate call
+
+        // types:
+            // send native coin
+            // send erc20
+            // send erc721
+            // change safe settings
+                // add owner with changing threshold
+                // remove owner with changing threshold
+                // swap owner
+                // change threshold
+                // change implementation
+                // set fallback handler
+                // enable module
+                // disable module
+            // module transaction
+            // custom contract call
+            // rejection transaction
+            // approve hash
+            // multi-send
+            // contract deployment transaction
+                // safe deployment transaction
+                // nft deployment transaction
+                // erc20 deployment transaction
+
+        // chains:
+            // Ethereum
+            // xDai
+            // Polygon
+            // Binance Smart Chain
+            // Energy Web Chain
+            // Volta
+            // Arbitrum
+            // Avalanche
+            // Goerli
+            // Rinkeby
+}

--- a/Packages/Ethereum/.gitignore
+++ b/Packages/Ethereum/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata

--- a/Packages/Ethereum/Package.swift
+++ b/Packages/Ethereum/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Ethereum",
+    platforms: [.iOS(.v14), .macOS(.v11)],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "Ethereum",
+            targets: ["Json", "JsonRpc2", "Ethereum"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(name: "Json"),
+        .testTarget(name: "JsonTests", dependencies: ["Json", "TestHelpers"]),
+
+        .target(name: "JsonRpc2", dependencies: ["Json"]),
+        .testTarget(name: "JsonRpc2Tests", dependencies: ["JsonRpc2", "TestHelpers"]),
+
+        .target(name: "Ethereum", dependencies: ["Json", "JsonRpc2"]),
+        .testTarget(name: "EthereumTests", dependencies: ["Ethereum", "TestHelpers"]),
+
+        .target(name: "TestHelpers")
+    ]
+)

--- a/Packages/Ethereum/README.md
+++ b/Packages/Ethereum/README.md
@@ -1,0 +1,3 @@
+# Ethereum
+
+Packages to work with Ethereum API

--- a/Packages/Ethereum/Sources/Ethereum/EthRpc1.swift
+++ b/Packages/Ethereum/Sources/Ethereum/EthRpc1.swift
@@ -381,8 +381,6 @@ public enum EthRpc1 {
 extension EthRpc1 {
     /// Returns the balance of the account of given address.
     public struct eth_getBalance: JsonRpc2Method, EhtRpc1AccountParams {
-        public static var name: String { "eth_getBalance" }
-
         /// Account to get balance of
         public var address: String
 
@@ -400,8 +398,6 @@ extension EthRpc1 {
 
     /// Returns the number of the most recent block seen by this client
     public struct eth_blockNumber: JsonRpc2Method, EthRpc1EmptyParams {
-        public static var name: String { "eth_blockNumber" }
-
         /// number of the latest block
         public typealias Return = String
 
@@ -411,8 +407,6 @@ extension EthRpc1 {
 
     /// Returns the current price per gas in wei.
     public struct eth_gasPrice: JsonRpc2Method, EthRpc1EmptyParams {
-        public static var name: String { "eth_gasPrice" }
-
         /// Gas price
         public typealias Return = String
 
@@ -421,8 +415,6 @@ extension EthRpc1 {
 
     /// Executes a new message call immediately without creating a transaction on the block chain.
     public struct eth_call: JsonRpc2Method, EthRpc1TransactionParams {
-        public static var name: String { "eth_call" }
-
         /// Transaction. NOTE: `from` field MUST be present.
         public var transaction: Transaction
 
@@ -436,8 +428,6 @@ extension EthRpc1 {
 
     /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
     public struct eth_estimateGas: JsonRpc2Method, EthRpc1TransactionParams {
-        public static var name: String { "eth_estimateGas" }
-
         /// Transaction. NOTE: `from` field MUST be present.
         public var transaction: Transaction
 
@@ -451,8 +441,6 @@ extension EthRpc1 {
 
     /// Submits a raw transaction.
     public struct eth_sendRawTransaction: JsonRpc2Method, EthRpc1TransactionParams {
-        public static var name: String { "eth_sendRawTransaction" }
-
         /// Transaction as bytes
         public var transaction: String
 
@@ -466,8 +454,6 @@ extension EthRpc1 {
 
     /// Returns the receipt of a transaction by transaction hash.
     public struct eth_getTransactionReceipt: JsonRpc2Method {
-        public static var name: String { "eth_getTransactionReceipt" }
-
         public var transactionHash: String
 
         /// Receipt Information or null if transaction not found
@@ -480,8 +466,6 @@ extension EthRpc1 {
 
     /// Returns the number of transactions sent from an address.
     public struct eth_getTransactionCount: JsonRpc2Method, EhtRpc1AccountParams {
-        public static var name: String { "eth_getTransactionCount" }
-
         /// Account to get balance of
         public var address: String
 

--- a/Packages/Ethereum/Sources/Ethereum/EthRpc1.swift
+++ b/Packages/Ethereum/Sources/Ethereum/EthRpc1.swift
@@ -1,0 +1,570 @@
+//
+//  EthRpc1.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 15.12.21.
+//
+
+import Foundation
+import JsonRpc2
+
+/// Namespace for the types defined in the Ethereum JSON-RPC 1.0 specification
+///
+/// See more:
+///   - https://raw.githubusercontent.com/ethereum/eth1.0-apis/assembled-spec/openrpc.json
+///   - https://eips.ethereum.org/EIPS/eip-1474
+public enum EthRpc1 {
+    public enum Transaction: Codable {
+        case legacy(TransactionLegacy)
+        case eip2930(Transaction2930)
+        case eip1559(Transaction1559)
+        /// not known type
+        case unknown
+
+        public init(from decoder: Decoder) throws {
+            enum Key: String, CodingKey { case type }
+            let container = try decoder.container(keyedBy: Key.self)
+            var type = try container.decode(String.self, forKey: .type)
+
+            if type.hasPrefix("0x") {
+                type.removeFirst(2)
+            }
+
+            guard let byte = UInt8(type, radix: 16) else {
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Invalid transaction `type` value: \(type)")
+                )
+            }
+
+            // Learn more:
+            // https://eips.ethereum.org/EIPS/eip-1559
+            // https://eips.ethereum.org/EIPS/eip-2930
+            // https://eips.ethereum.org/EIPS/eip-2718
+
+            // Type of a transaction with access list and chain Id. Defined in EIP-2930
+            let EIP_2930_TYPE: UInt8 = 0x01
+
+            // Type of a transaction with priority fee. Defined in EIP-1559
+            let EIP_1559_TYPE: UInt8 = 0x02
+
+            // Legacy transaction type value. Defined in EIP-2718
+            let LEGACY_RANGE_TYPE: ClosedRange<UInt8> = (0xc0...0xfe)
+
+            // All possible values for the 'type' according to EIP-2718
+            let EIP_2718_RANGE_TYPE: ClosedRange<UInt8> = (0x00...0x7f)
+
+            // Reserved value for the 'type' according to EIP-2718
+            let EIP_2718_RESERVED_TYPE: UInt8 = 0xff
+
+            switch byte {
+            case EIP_2930_TYPE:
+                self = try .eip2930(.init(from: decoder))
+            case EIP_1559_TYPE:
+                self = try .eip1559(.init(from: decoder))
+            case LEGACY_RANGE_TYPE:
+                self = try .legacy(.init(from: decoder))
+            case EIP_2718_RANGE_TYPE:
+                // backwards compatibility:
+                // EIP-2718 transaction but we don't know it's type
+                fallthrough
+            case EIP_2718_RESERVED_TYPE:
+                fallthrough
+            default:
+                self = .unknown
+            }
+        }
+    }
+
+    public struct TransactionLegacy: Codable {
+        /// type according to EIP-2718
+        ///
+        /// Must be in range [0xc0, 0xfe]
+        public var type: String
+
+        public var nonce: String
+
+        /// to address
+        public var to: String?
+
+        /// gas limit
+        public var gas: String
+
+        public var value: String
+
+        /// input data
+        public var input: String
+
+        /// The gas price willing to be paid by the sender in wei
+        public var gasPrice: String
+
+        /// Chain ID that this transaction is valid on.
+        public var chainId: String?
+
+        /// from address
+        public var from: String?
+
+        public var blockHash: String?
+
+        public var blockNumber: String?
+
+        /// Transaction hash
+        public var hash: String?
+
+        public var transactionIndex: String?
+
+        /// Signature 'v' component
+        public var v: String?
+
+        /// Signature 'r' component
+        public var r: String?
+
+        /// Signature 's' component
+        public var s: String?
+        public init(type: String, nonce: String, to: String?, gas: String, value: String, input: String, gasPrice: String, chainId: String?, from: String?, blockHash: String?, blockNumber: String?, hash: String?, transactionIndex: String?, v: String?, r: String?, s: String?) {
+            self.type = type
+            self.nonce = nonce
+            self.to = to
+            self.gas = gas
+            self.value = value
+            self.input = input
+            self.gasPrice = gasPrice
+            self.chainId = chainId
+            self.from = from
+            self.blockHash = blockHash
+            self.blockNumber = blockNumber
+            self.hash = hash
+            self.transactionIndex = transactionIndex
+            self.v = v
+            self.r = r
+            self.s = s
+        }
+    }
+
+    /// EIP-2930 transaction.
+    public struct Transaction2930: Codable {
+        /// type according to EIP-2718
+        ///
+        /// Must be 0x01 per specification
+        public var type: String
+
+        public var nonce: String
+
+        /// to address
+        public var to: String?
+
+        /// gas limit
+        public var gas: String
+
+        public var value: String
+
+        /// input data
+        public var input: String
+
+        /// The gas price willing to be paid by the sender in wei
+        public var gasPrice: String
+
+        /// EIP-2930 access list
+        public var accessList: [AccessListEntry]
+
+        /// Chain ID that this transaction is valid on.
+        public var chainId: String
+
+        /// from address
+        public var from: String?
+
+        public var blockHash: String?
+
+        public var blockNumber: String?
+
+        /// Transaction hash
+        public var hash: String?
+
+        public var transactionIndex: String?
+
+        /// The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
+        public var yParity: String?
+
+        /// Signature 'r' component
+        public var r: String?
+
+        /// Signature 's' component
+        public var s: String?
+
+        public init(type: String, nonce: String, to: String?, gas: String, value: String, input: String, gasPrice: String, accessList: [EthRpc1.AccessListEntry], chainId: String, from: String?, blockHash: String?, blockNumber: String?, hash: String?, transactionIndex: String?, yParity: String?, r: String?, s: String?) {
+            self.type = type
+            self.nonce = nonce
+            self.to = to
+            self.gas = gas
+            self.value = value
+            self.input = input
+            self.gasPrice = gasPrice
+            self.accessList = accessList
+            self.chainId = chainId
+            self.from = from
+            self.blockHash = blockHash
+            self.blockNumber = blockNumber
+            self.hash = hash
+            self.transactionIndex = transactionIndex
+            self.yParity = yParity
+            self.r = r
+            self.s = s
+        }
+    }
+
+    /// EIP-1559 transaction.
+    public struct Transaction1559: Codable {
+        /// type according to EIP-2718
+        ///
+        /// Must be 0x02 per specification
+        public var type: String
+
+        public var nonce: String
+
+        /// to address
+        public var to: String?
+
+        /// gas limit
+        public var gas: String
+
+        public var value: String
+
+        /// input data
+        public var input: String
+
+        /// Maximum fee per gas the sender is willing to pay to miners in wei
+        public var maxPriorityFeePerGas: String
+
+        /// The maximum total fee per gas the sender is willing to pay (includes the network / base fee and miner / priority fee) in wei
+        public var maxFeePerGas: String
+
+        /// EIP-2930 access list
+        public var accessList: [AccessListEntry]
+
+        /// Chain ID that this transaction is valid on.
+        public var chainId: String
+
+        /// from address
+        public var from: String?
+
+        public var blockHash: String?
+
+        public var blockNumber: String?
+
+        /// Transaction hash
+        public var hash: String?
+
+        public var transactionIndex: String?
+
+        /// The parity (0 for even, 1 for odd) of the y-value of the secp256k1 signature.
+        public var yParity: String?
+
+        /// Signature 'r' component
+        public var r: String?
+
+        /// Signature 's' component
+        public var s: String?
+
+        public init(type: String, nonce: String, to: String?, gas: String, value: String, input: String, maxPriorityFeePerGas: String, maxFeePerGas: String, accessList: [EthRpc1.AccessListEntry], chainId: String, from: String?, blockHash: String?, blockNumber: String?, hash: String?, transactionIndex: String?, yParity: String?, r: String?, s: String?) {
+            self.type = type
+            self.nonce = nonce
+            self.to = to
+            self.gas = gas
+            self.value = value
+            self.input = input
+            self.maxPriorityFeePerGas = maxPriorityFeePerGas
+            self.maxFeePerGas = maxFeePerGas
+            self.accessList = accessList
+            self.chainId = chainId
+            self.from = from
+            self.blockHash = blockHash
+            self.blockNumber = blockNumber
+            self.hash = hash
+            self.transactionIndex = transactionIndex
+            self.yParity = yParity
+            self.r = r
+            self.s = s
+        }
+    }
+
+    public struct Log: Codable {
+        public var removed: Bool?
+        public var logIndex: String?
+        public var transactionIndex: String?
+        public var transactionHash: String?
+        public var blockHash: String?
+        public var blockNumber: String?
+        public var address: String?
+        public var data: String?
+        public var topics: [String]?
+
+        public init(removed: Bool?, logIndex: String?, transactionIndex: String?, transactionHash: String?, blockHash: String?, blockNumber: String?, address: String?, data: String?, topics: [String]?) {
+            self.removed = removed
+            self.logIndex = logIndex
+            self.transactionIndex = transactionIndex
+            self.transactionHash = transactionHash
+            self.blockHash = blockHash
+            self.blockNumber = blockNumber
+            self.address = address
+            self.data = data
+            self.topics = topics
+        }
+    }
+
+    public struct ReceiptInfo: Codable {
+        public var transactionHash: String
+
+        public var transactionIndex: String
+
+        public var blockHash: String
+
+        public var blockNumber: String
+
+        public var from: String
+
+        /// Address of the receiver or null in a contract creation transaction.
+        public var to: String?
+
+        /// The sum of gas used by this transaction and all preceding transactions in the same block.
+        public var cumulativeGasUsed: String
+
+        /// The amount of gas used for this specific transaction alone.
+        public var gasUsed: String
+
+        /// The contract address created, if the transaction was a contract creation, otherwise null.
+        public var contractAddress: String?
+
+        public var logs: [Log]
+
+        public var logsBloom: String
+
+        /// The post-transaction state root. Only specified for transactions included before the Byzantium upgrade.
+        public var root: String?
+
+        /// Either 1 (success) or 0 (failure). Only specified for transactions included after the Byzantium upgrade.
+        public var status: String?
+
+        /// The actual value per gas deducted from the senders account. Before EIP-1559, this is equal to the transaction's gas price. After, it is equal to baseFeePerGas + min(maxFeePerGas - baseFeePerGas, maxPriorityFeePerGas).
+        public var effectiveGasPrice: String
+
+        public init(transactionHash: String, transactionIndex: String, blockHash: String, blockNumber: String, from: String, to: String?, cumulativeGasUsed: String, gasUsed: String, contractAddress: String?, logs: [EthRpc1.Log], logsBloom: String, root: String?, status: String?, effectiveGasPrice: String) {
+            self.transactionHash = transactionHash
+            self.transactionIndex = transactionIndex
+            self.blockHash = blockHash
+            self.blockNumber = blockNumber
+            self.from = from
+            self.to = to
+            self.cumulativeGasUsed = cumulativeGasUsed
+            self.gasUsed = gasUsed
+            self.contractAddress = contractAddress
+            self.logs = logs
+            self.logsBloom = logsBloom
+            self.root = root
+            self.status = status
+            self.effectiveGasPrice = effectiveGasPrice
+        }
+    }
+
+    /// Access list entry
+    public struct AccessListEntry: Codable {
+        public var address: String?
+        public var storageKeys: [String]?
+
+        public init(address: String?, storageKeys: [String]?) {
+            self.address = address
+            self.storageKeys = storageKeys
+        }
+    }
+}
+
+extension EthRpc1 {
+    /// Returns the balance of the account of given address.
+    public struct eth_getBalance: JsonRpc2Method, EhtRpc1AccountParams {
+        public static var name: String { "eth_getBalance" }
+
+        /// Account to get balance of
+        public var address: String
+
+        /// Block number or tag
+        public var block: String
+
+        /// Balance
+        public typealias Return = String
+        
+        public init(address: String, block: String) {
+            self.address = address
+            self.block = block
+        }
+    }
+
+    /// Returns the number of the most recent block seen by this client
+    public struct eth_blockNumber: JsonRpc2Method, EthRpc1EmptyParams {
+        public static var name: String { "eth_blockNumber" }
+
+        /// number of the latest block
+        public typealias Return = String
+
+        public init() {}
+    }
+
+
+    /// Returns the current price per gas in wei.
+    public struct eth_gasPrice: JsonRpc2Method, EthRpc1EmptyParams {
+        public static var name: String { "eth_gasPrice" }
+
+        /// Gas price
+        public typealias Return = String
+
+        public init() {}
+    }
+
+    /// Executes a new message call immediately without creating a transaction on the block chain.
+    public struct eth_call: JsonRpc2Method, EthRpc1TransactionParams {
+        public static var name: String { "eth_call" }
+
+        /// Transaction. NOTE: `from` field MUST be present.
+        public var transaction: Transaction
+
+        /// Return data
+        public typealias Return = String
+
+        public init(transaction: EthRpc1.Transaction) {
+            self.transaction = transaction
+        }
+    }
+
+    /// Generates and returns an estimate of how much gas is necessary to allow the transaction to complete.
+    public struct eth_estimateGas: JsonRpc2Method, EthRpc1TransactionParams {
+        public static var name: String { "eth_estimateGas" }
+
+        /// Transaction. NOTE: `from` field MUST be present.
+        public var transaction: Transaction
+
+        /// Gas used
+        public typealias Return = String
+
+        public init(transaction: EthRpc1.Transaction) {
+            self.transaction = transaction
+        }
+    }
+
+    /// Submits a raw transaction.
+    public struct eth_sendRawTransaction: JsonRpc2Method, EthRpc1TransactionParams {
+        public static var name: String { "eth_sendRawTransaction" }
+
+        /// Transaction as bytes
+        public var transaction: String
+
+        /// Transaction hash, or the zero hash if the transaction is not yet available
+        public typealias Return = String
+
+        public init(transaction: String) {
+            self.transaction = transaction
+        }
+    }
+
+    /// Returns the receipt of a transaction by transaction hash.
+    public struct eth_getTransactionReceipt: JsonRpc2Method {
+        public static var name: String { "eth_getTransactionReceipt" }
+
+        public var transactionHash: String
+
+        /// Receipt Information or null if transaction not found
+        public typealias Return = ReceiptInfo?
+
+        public init(transactionHash: String) {
+            self.transactionHash = transactionHash
+        }
+    }
+
+    /// Returns the number of transactions sent from an address.
+    public struct eth_getTransactionCount: JsonRpc2Method, EhtRpc1AccountParams {
+        public static var name: String { "eth_getTransactionCount" }
+
+        /// Account to get balance of
+        public var address: String
+
+        /// Block number or tag
+        public var block: String
+
+        /// Transaction count
+        public typealias Return = String
+
+        public init(address: String, block: String) {
+            self.address = address
+            self.block = block
+        }
+    }
+}
+
+public protocol EthRpc1EmptyParams: Codable {
+    init()
+}
+
+extension EthRpc1EmptyParams {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        _ = try container.decode([String].self)
+        self.init()
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode([String]())
+    }
+}
+
+// reusable codable implementation of account parameters for methods that query account state
+public protocol EhtRpc1AccountParams: Codable {
+    var address: String { get set }
+    var block: String { get set }
+    init(address: String, block: String)
+}
+
+extension EhtRpc1AccountParams {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let address = try container.decode(String.self)
+        let block = try container.decode(String.self)
+        self.init(address: address, block: block)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(address)
+        try container.encode(block)
+    }
+}
+
+public protocol EthRpc1TransactionParams: Codable {
+    associatedtype Transaction: Codable
+    var transaction: Transaction  { get set }
+    init(transaction: Transaction)
+}
+
+extension EthRpc1TransactionParams {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let transaction = try container.decode(Transaction.self)
+        self.init(transaction: transaction)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(transaction)
+    }
+}
+
+extension EthRpc1.eth_getTransactionReceipt: Codable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let transaction = try container.decode(String.self)
+        self.init(transactionHash: transaction)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        try container.encode(transactionHash)
+    }
+}

--- a/Packages/Ethereum/Sources/Ethereum/InfuraError.swift
+++ b/Packages/Ethereum/Sources/Ethereum/InfuraError.swift
@@ -1,0 +1,19 @@
+//
+//  InfuraError.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+// Infura server errors
+// |  CODE  |            MESSAGE             |                    MEANING                    |   CATEGORY   |
+// | ------ | ------------------------------ | --------------------------------------------- | ------------ |
+// | -32000 | Invalid input                  | Missing or invalid parameters                 | non-standard |
+// | -32001 | Resource not found             | Requested resource not found                  | non-standard |
+// | -32002 | Resource unavailable           | Requested resource not available              | non-standard |
+// | -32003 | Transaction rejected           | Transaction creation failed                   | non-standard |
+// | -32004 | Method not supported           | Method is not implemented                     | non-standard |
+// | -32005 | Limit exceeded                 | Request exceeds defined limit                 | non-standard |
+// | -32006 | JSON-RPC version not supported | Version of JSON-RPC protocol is not supported | non-standard |

--- a/Packages/Ethereum/Sources/Json/Json.swift
+++ b/Packages/Ethereum/Sources/Json/Json.swift
@@ -1,0 +1,321 @@
+//
+//  Json.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 15.12.21.
+//
+
+import Foundation
+
+// wrappers over basic json types in order to be able to encode and decode
+// dynamic arrays or dictionaries in other types
+// otherwise we have to know in advance concrete type fro decoding, which is possible
+// but doesn't solve a situation when decoding of that concrete type fails
+// and we still want to see what actual json we received.
+
+public enum Json {
+    public struct Object: Hashable {
+        public var members: [String: Element]
+
+        public init(members: [String: Element]) {
+            self.members = members
+        }
+    }
+
+    public struct Array: Hashable {
+        public var elements: [Element]
+
+        public init(elements: [Element]) {
+            self.elements = elements
+        }
+    }
+
+    public enum Element: Hashable {
+        case object(Object)
+        case array(Array)
+        case string(String)
+        case int(Int)
+        case uint(UInt)
+        case double(Double)
+        case bool(Bool)
+        case null
+    }
+
+    struct Key: CodingKey {
+        var stringValue: String
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        var intValue: Int?
+
+        init?(intValue: Int) {
+            self.intValue = intValue
+            self.stringValue = String(intValue)
+        }
+    }
+}
+
+extension Json.Element: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        // for each case with associated value, encode the value directly
+        switch self {
+        case .object(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .uint(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .bool(let value):
+            try container.encode(value)
+        case .null:
+            // for null, encodeNil
+            try container.encodeNil()
+        }
+    }
+}
+
+extension Json.Element: Decodable {
+    public init(from decoder: Decoder) throws {
+        // try decode primitve value
+        if let container = try? decoder.singleValueContainer() {
+            if let value = try? container.decode(String.self) {
+                self = .string(value)
+                return
+            } else if let value = try? container.decode(Int.self) {
+                self = .int(value)
+                return
+            } else if let value = try? container.decode(UInt.self) {
+                self = .uint(value)
+                return
+            } else if let value = try? container.decode(Double.self) {
+                self = .double(value)
+                return
+            } else if let value = try? container.decode(Bool.self) {
+                self = .bool(value)
+                return
+            } else if container.decodeNil() {
+                self = .null
+                return
+            } else {
+                // not a single value, try something else.
+            }
+        }
+
+        // try decoding object
+        if (try? decoder.container(keyedBy: Json.Key.self)) != nil {
+
+            let container = try decoder.singleValueContainer()
+            self = try .object(container.decode(Json.Object.self))
+
+        }
+        // try decoding array
+        else if (try? decoder.unkeyedContainer()) != nil {
+
+            let container = try decoder.singleValueContainer()
+            self = try .array(container.decode(Json.Array.self))
+
+        }
+        // default to null
+        else {
+            self = .null
+        }
+    }
+}
+
+extension Json.Object: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Json.Key.self)
+        for (key, member) in members {
+            if let codingKey = KeyedEncodingContainer<Json.Key>.Key(stringValue: key) {
+                try container.encode(member, forKey: codingKey)
+            }
+        }
+    }
+}
+extension Json.Object: Decodable {
+    public init(from decoder: Decoder) throws {
+        members = [:]
+        let container = try decoder.container(keyedBy: Json.Key.self)
+        for key in container.allKeys {
+            let member = try container.decode(Json.Element.self, forKey: key)
+            members[key.stringValue] = member
+        }
+    }
+}
+
+extension Json.Array: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        for element in elements {
+            try container.encode(element)
+        }
+    }
+}
+
+extension Json.Array: Decodable {
+    public init(from decoder: Decoder) throws {
+        elements = []
+        var container = try decoder.unkeyedContainer()
+        while !container.isAtEnd {
+            let element = try container.decode(Json.Element.self)
+            elements.append(element)
+        }
+    }
+}
+
+// init from encodable
+public protocol EncodableConvertible {
+    init<T: Encodable>(value: T) throws
+}
+
+extension EncodableConvertible where Self: Decodable {
+    // converts encodable value to the self assuming they encode to the same JSON elements
+    public init<T: Encodable>(value: T) throws {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(value)
+        let decoder = JSONDecoder()
+        self = try decoder.decode(Self.self, from: data)
+    }
+}
+
+// convert to Decodable
+// converts to decodable type assuming that self and T has the same JSON elements
+public protocol DecodableConvertible {
+    func convert<T: Decodable>(to type: T.Type) throws -> T
+}
+
+extension DecodableConvertible where Self: Encodable {
+    public func convert<T: Decodable>(to type: T.Type) throws -> T {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        let decoder = JSONDecoder()
+        let value = try decoder.decode(type, from: data)
+        return value
+    }
+}
+
+// default implementation
+extension Json.Element: EncodableConvertible, DecodableConvertible {}
+
+
+// A way to encode and decode NSError to Json
+extension Json {
+    public struct NSError: Codable {
+        var domain: String
+        var code: Int
+        var userInfo: Json.Object
+    }
+}
+
+extension Json.NSError: JsonConvertible {
+    public init(_ nsError: Foundation.NSError) {
+        domain = nsError.domain
+        code = nsError.code
+        userInfo = Json.Object(
+            members: Dictionary(uniqueKeysWithValues: nsError.userInfo.map({ (key: String, value: Any) -> (String, Json.Element) in
+                // sometimes people extend String with Swift.Error, we don't want to encode that as NSError
+                if let value = value as? String {
+                    return (key, Json.Element(any: value))
+                } else if let value = value as? Foundation.NSError {
+                    // handle nexted NSError values
+                    return (key, Json.Element(any: Json.NSError(value)))
+                } else {
+                    return (key, Json.Element(any: value))
+                }
+            }))
+        )
+    }
+
+
+    public func nsError() -> NSError {
+        NSError(domain: domain, code: code, userInfo: Dictionary(uniqueKeysWithValues: userInfo.members.map({ (key: String, value: Json.Element) -> (String, Any) in
+
+            let resultValue = value.toAny()
+
+            // handle nested NSError values
+            if let object = resultValue as? [String: Any],
+               let domain = object["domain"] as? String,
+               let code = object["code"] as? Int,
+               let userInfo = object["userInfo"] as? [String: Any] {
+                return (key, Foundation.NSError(domain: domain, code: code, userInfo: userInfo) as Any)
+            } else {
+                return (key, resultValue)
+            }
+        })))
+    }
+}
+
+// Allows to convert any value to Json element
+public protocol JsonConvertible {
+    func toJson() -> Json.Element
+}
+
+extension JsonConvertible where Self: Encodable {
+    public func toJson() -> Json.Element {
+        (try? Json.Element(value: self)) ?? .null
+    }
+}
+
+// Allows to convert to and from Swift.Any erased type
+public protocol AnyConvertible {
+    func toAny() -> Any
+    init(any value: Any)
+}
+
+// Convert to and from elements, including nested JsonConvertible values
+extension Json.Element: AnyConvertible {
+    public func toAny() -> Any {
+        switch self {
+        case .object(let object):
+            return Dictionary(uniqueKeysWithValues: object.members.map { (key: String, value: Json.Element) in
+                (key, value.toAny())
+            })
+        case .array(let array):
+            return array.elements.map { $0.toAny() }
+        case .string(let value):
+            return value as Any
+        case .int(let value):
+            return value as Any
+        case .uint(let value):
+            return value as Any
+        case .double(let value):
+            return value as Any
+        case .bool(let value):
+            return value as Any
+        case .null:
+            return NSNull() as Any
+        }
+    }
+
+    public init(any value: Any) {
+        if let value = value as? Int {
+            self = .int(value)
+        } else if let value = value as? UInt {
+            self = .uint(value)
+        } else if let value = value as? Double {
+            self = .double(value)
+        } else if let value = value as? Bool {
+            self = .bool(value)
+        } else if let value = value as? String {
+            self = .string(value)
+        } else if let value = value as? [Any] {
+            self =  .array(Json.Array(elements: value.map(Json.Element.init(any:))))
+        } else if let value = value as? [String: Any] {
+            self =  .object(Json.Object(members: Dictionary(uniqueKeysWithValues: value.map { ($0, Json.Element(any: $1)) } )))
+        } else if let value = value as? JsonConvertible {
+            self = value.toJson()
+        } else {
+            self = .null
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/AsyncClient.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/AsyncClient.swift
@@ -1,0 +1,56 @@
+//
+//  AsyncClient.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    @available(iOS 15.0.0, *)
+    @available(macOS 12.0.0, *)
+    public struct AsyncClient {
+        public var transport: JsonRpc2ClientAsyncTransport
+        public var serializer: JsonRpc2ClientSerializer
+
+        public init(transport: JsonRpc2ClientAsyncTransport, serializer: JsonRpc2ClientSerializer) {
+            self.transport = transport
+            self.serializer = serializer
+        }
+
+        public func send(request: JsonRpc2.Request) async throws -> JsonRpc2.Response? {
+            try await send(request: request, validator: JsonRpc2.RequestValidator())
+        }
+
+        public func send(request: JsonRpc2.BatchRequest) async throws -> JsonRpc2.BatchResponse? {
+            try await send(request: request, validator: JsonRpc2.BatchRequestValidator(JsonRpc2.RequestValidator()))
+        }
+
+        public func send<Request, Response, Validator>(
+            request: Request,
+            validator: Validator
+        )
+        async throws -> Response?
+        where Validator: JsonRpc2ClientValidator,
+              Validator.Request == Request,
+              Validator.Response == Response,
+              Request: Encodable,
+              Response: Decodable
+        {
+            try validator.validate(request: request)
+            let jsonRequest: Data = try serializer.toJson(value: request)
+
+            let jsonResponse: Data = try await transport.send(data: jsonRequest)
+
+            if jsonResponse.isEmpty {
+                try validator.validate(response: nil, for: request)
+                return nil
+            }
+            // else response is not empty.
+            let response: Response = try serializer.fromJson(data: jsonResponse)
+            try validator.validate(response: response, for: request)
+            return response
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/AsyncHTTPTransport.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/AsyncHTTPTransport.swift
@@ -1,0 +1,32 @@
+//
+//  AsyncHTTPTransport.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    @available(iOS 15.0.0, *)
+    @available(macOS 12.0.0, *)
+    public struct AsyncHTTPTransport: JsonRpc2ClientAsyncTransport {
+        public var url: String = ""
+
+        public init(url: String = "") {
+            self.url = url
+        }
+
+        public func send(data: Data) async throws -> Data {
+            guard let url = URL(string: url) else {
+                throw JsonRpc2.Error.invalidServerUrl
+            }
+            var urlRequest = URLRequest(url: url)
+            urlRequest.httpMethod = "POST"
+            urlRequest.httpBody = data
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let (data, _) = try await URLSession.shared.data(for: urlRequest)
+            return data
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/BatchRequestValidator.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/BatchRequestValidator.swift
@@ -1,0 +1,92 @@
+//
+//  BatchRequestValidator.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    public struct BatchRequestValidator<V>: JsonRpc2ClientValidator where V: JsonRpc2ClientValidator, V.Request == JsonRpc2.Request, V.Response == JsonRpc2.Response {
+        public let singleRequesValidator: V
+
+        public init(_ validator: V) {
+            singleRequesValidator = validator
+        }
+
+        public func validate(request batchRequest: JsonRpc2.BatchRequest) throws {
+            // there must be at least one value in the batch for it to be valid
+            if batchRequest.requests.isEmpty {
+                throw JsonRpc2.Error.invalidRequest.with(data: .string("batch must have at least one request"))
+            }
+
+            for requestOrNil in batchRequest.requests {
+                // batch may have 'nil' inside in case it was decoded from a JSON that was invalid batch
+                if let request = requestOrNil {
+                    try singleRequesValidator.validate(request: request)
+                } else {
+                    throw JsonRpc2.Error.invalidRequest.with(data: .string("all requests must be valid objects"))
+                }
+            }
+        }
+
+        // requires
+        // batch reqeust without null requests
+        // each request is valid request per client-side validation
+        public func validate(response batchResponse: JsonRpc2.BatchResponse?, for request: JsonRpc2.BatchRequest) throws {
+            let batchRequests = request.requests.compactMap { $0 }
+
+            // A Response object SHOULD exist for each Request object, except that there SHOULD NOT be any Response objects for notifications.
+            // If there are no Response objects contained within the Response array as it is to be sent to the client, the server MUST NOT return an empty Array and should return nothing at all.
+
+            // corollary: if we send batch with all notifications then the batch response must be nil.
+            let isAllNotifications = batchRequests.allSatisfy { $0.id == nil }
+            if isAllNotifications && batchResponse != nil {
+                throw JsonRpc2.Error.invalidResponse.with(data: .string("server must not return response for batch with all notifications"))
+            }
+
+            // else we must have some response
+            guard let batchResponse = batchResponse else {
+                throw JsonRpc2.Error.invalidResponse.with(data: .string("expected server response but got nothing"))
+            }
+
+            switch batchResponse {
+            case .response(let singleResponse):
+                // If the batch rpc call itself fails to be recognized as an valid JSON or as an Array with at least one value, the response from the Server MUST be a single Response object.
+                //
+                // NOTE: converse is not true, it is possible to get single response even for a valid batch. But this
+                // behavior is undefined in the spec, and we treat it as error. (null id)
+                //
+                // We create a fake request for validation because it's undefined which request we would validate against.
+                let fakeRequest = JsonRpc2.Request(jsonrpc: "2.0", method: "", params: nil, id: .null)
+                try singleRequesValidator.validate(response: singleResponse, for: fakeRequest)
+            case .array(let responses):
+                // A Response object SHOULD exist for each Request object, except that there SHOULD NOT be any Response objects for notifications.
+                // The Client SHOULD match contexts between the set of Request objects and the resulting set of Response objects based on the id member within each Object.
+                // The Response objects being returned from a batch call MAY be returned in any order within the Array.
+
+                let responsesById = Dictionary(uniqueKeysWithValues: responses.map { ($0.id, $0) })
+
+                for request in batchRequests {
+                    // skip notifications
+                    guard let requestId = request.id else { continue }
+
+                    guard let response = responsesById[requestId] else {
+                        throw JsonRpc2.Error.invalidResponse.with(data: .string("response not found for request id '\(requestId)'"))
+                    }
+
+                    try singleRequesValidator.validate(response: response, for: request)
+                }
+            }
+        }
+
+        public func error(for request: JsonRpc2.BatchRequest, value: JsonRpc2.Error) -> JsonRpc2.BatchResponse? {
+            JsonRpc2.BatchResponse.response(JsonRpc2.Response(
+                jsonrpc: "2.0",
+                result: nil,
+                error: value,
+                id: .null))
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/Client.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/Client.swift
@@ -1,0 +1,110 @@
+//
+//  Client.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 15.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    // The Client is defined as the origin of Request objects and the handler of Response objects.
+    public struct Client {
+        public var transport: JsonRpc2ClientTransport
+        public var serializer: JsonRpc2ClientSerializer
+
+        public init(transport: JsonRpc2ClientTransport, serializer: JsonRpc2ClientSerializer) {
+            self.transport = transport
+            self.serializer = serializer
+        }
+
+        public func send(request: JsonRpc2.Request, completion: @escaping (JsonRpc2.Response?) -> Void) {
+            send(request: request, validator: JsonRpc2.RequestValidator(), completion: completion)
+        }
+
+        public func send(request: JsonRpc2.BatchRequest, completion: @escaping (JsonRpc2.BatchResponse?) -> Void) {
+            send(request: request, validator: JsonRpc2.BatchRequestValidator(JsonRpc2.RequestValidator()), completion: completion)
+        }
+
+        // Generic send allows to have both batch and single request types to use the  same algorithm.
+        public func send<Request, Response, Validator>(
+            request: Request,
+            validator: Validator,
+            completion: @escaping (Response?) -> Void
+        )
+        where Validator: JsonRpc2ClientValidator,
+              Validator.Request == Request,
+              Validator.Response == Response,
+              Request: Encodable,
+              Response: Decodable
+        {
+            // validate request
+            do {
+                try validator.validate(request: request)
+            } catch let jsonRpc2Error as JsonRpc2.Error {
+                completion(validator.error(for: request, value: jsonRpc2Error))
+            } catch let programmersError {
+                fatalError("Request validation fails with unexpected error: \(programmersError)")
+            }
+
+            // convert request to json
+            let jsonRequest: Data
+            do {
+                jsonRequest = try serializer.toJson(value: request)
+            } catch let swiftEncodingError {
+                completion(validator.error(for: request, value: .parseError.with(error: swiftEncodingError)))
+                return
+            }
+
+            // send request
+            transport.send(data: jsonRequest) { result in
+                // handle response
+                switch result {
+                case .success(let jsonResponse):
+
+                    // empty response
+                    if jsonResponse.isEmpty {
+
+                        // validate empty response
+                        do {
+                            try validator.validate(response: nil, for: request)
+                        } catch let jsonRpc2Error as JsonRpc2.Error {
+                            completion(validator.error(for: request, value: jsonRpc2Error))
+                            return
+                        } catch let programmerError {
+                            fatalError("Empty response validation fails with unexpected error: \(programmerError)")
+                        }
+                        // else valid response
+                        completion(nil)
+                        return
+                    }
+                    // else response is not empty.
+
+                    // convert response from json
+                    let response: Response
+                    do {
+                        response = try serializer.fromJson(data: jsonResponse)
+                    } catch let swiftDecodingError {
+                        completion(validator.error(for: request, value: .parseResponseError.with(error: swiftDecodingError)))
+                        return
+                    }
+
+                    // validate response
+                    do {
+                        try validator.validate(response: response, for: request)
+                    } catch let jsonRpc2Error as JsonRpc2.Error {
+                        completion(validator.error(for: request, value: jsonRpc2Error))
+                        return
+                    } catch let programmerError {
+                        fatalError("Response validation fails with unexpected error: \(programmerError)")
+                    }
+                    // else handle valid response
+                    completion(response)
+
+                case .failure(let lowLevelSendingError):
+                    completion(validator.error(for: request, value: .requestFailed.with(error: lowLevelSendingError)))
+                }
+            }
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/ClientError.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/ClientError.swift
@@ -1,0 +1,34 @@
+//
+//  ClientError.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+// Client errors
+extension JsonRpc2.Error {
+    // |  code  |       message        |                      meaning                      |
+    // | ------ | -------------------- | ------------------------------------------------- |
+    // | -33000 | Parse Response error | Invalid JSON Response was received by the client. |
+    // | -33001 | Request failed       | Request to the server failed.                     |
+    // | -33002 | Invalid server url   | Server URL string is invalid.                     |
+    // | -33003 | URLSession error     | Unexpected response parameters from URL Session.  |
+    // | -33004 | Invalid Response     | Invalid Response received by the client.          |
+
+    // Invalid JSON Response was received by the client.
+    public static let parseResponseError = JsonRpc2.Error(code: -33000, message: "Parse Response error", data: nil)
+
+    // Request to the server failed.
+    public static let requestFailed = JsonRpc2.Error(code: -33001, message: "Request failed", data: nil)
+
+    // Server URL string is invalid.
+    public static let invalidServerUrl = JsonRpc2.Error(code: -33002, message: "Invlaid server url", data: nil)
+
+    // Unexpected response parameters from URL Session.
+    public static let urlSessionError = JsonRpc2.Error(code: -33003, message: "URLSession error", data: nil)
+
+    // Invalid Response received by the client.
+    public static let invalidResponse = JsonRpc2.Error(code: -33004, message: "Invalid Response", data: nil)
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/ClientHTTPTransport.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/ClientHTTPTransport.swift
@@ -1,0 +1,45 @@
+//
+//  ClientHTTPTransport.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    public struct ClientHTTPTransport: JsonRpc2ClientTransport {
+        public var url: String = ""
+
+        public init(url: String = "") {
+            self.url = url
+        }
+
+        public func send(data: Data, completion: @escaping (Result<Data, Swift.Error>) -> Void) {
+            guard var urlRequest = URL(string: url).map({ URLRequest.init(url: $0) }) else {
+                completion(.failure(JsonRpc2.Error.invalidServerUrl))
+                return
+            }
+            urlRequest.httpMethod = "POST"
+            urlRequest.httpBody = data
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let dataTask = URLSession.shared.dataTask(with: urlRequest) { dataOrNil, _, errorOrNil in
+                // From the docs:
+                // If the request completes successfully, the data parameter of the completion handler block
+                // contains the resource data, and the error parameter is nil.
+                //
+                // If the request fails, the data parameter is nil and the error parameter
+                // contain information about the failure.
+                if let data = dataOrNil, errorOrNil == nil {
+                    completion(.success(data))
+                } else if let error = errorOrNil {
+                    completion(.failure(error))
+                } else {
+                    completion(.failure(JsonRpc2.Error.urlSessionError))
+                }
+            }
+            dataTask.resume()
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/DefaultSerializer.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/DefaultSerializer.swift
@@ -1,0 +1,26 @@
+//
+//  DefaultSerializer.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    public struct DefaultSerializer: JsonRpc2ClientSerializer {
+        public init() {}
+
+        public func toJson<T: Encodable>(value: T) throws -> Data {
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(value)
+            return data
+        }
+
+        public func fromJson<T: Decodable>(data: Data) throws -> T {
+            let decoder = JSONDecoder()
+            let value = try decoder.decode(T.self, from: data)
+            return value
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2.swift
@@ -1,0 +1,373 @@
+//
+//  JsonRpc2.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 15.12.21.
+//
+
+import Foundation
+import Json
+
+public enum JsonRpc2 {
+    public struct Request {
+        public var jsonrpc: String
+        public var method: String
+        public var params: Params?
+        public var id: Id?
+
+        public init(jsonrpc: String, method: String, params: JsonRpc2.Params?, id: JsonRpc2.Id?) {
+            self.jsonrpc = jsonrpc
+            self.method = method
+            self.params = params
+            self.id = id
+        }
+    }
+
+    public enum Params {
+        case array(Json.Array)
+        case object(Json.Object)
+    }
+
+    public enum Id: Hashable {
+        case string(String)
+        case int(Int)
+        case uint(UInt)
+        case double(Double)
+        case null
+    }
+
+    public struct Response {
+        public var jsonrpc: String
+        public var result: Json.Element?
+        public var error: Error?
+        public var id: Id
+
+        public init(jsonrpc: String, result: Json.Element?, error: JsonRpc2.Error?, id: JsonRpc2.Id) {
+            self.jsonrpc = jsonrpc
+            self.result = result
+            self.error = error
+            self.id = id
+        }
+    }
+
+    public struct Error: Swift.Error {
+        public var code: Int
+        public var message: String
+        public var data: Json.Element?
+
+        public init(code: Int, message: String, data: Json.Element?) {
+            self.code = code
+            self.message = message
+            self.data = data
+        }
+    }
+
+    public struct BatchRequest {
+        public var requests: [Request?]
+
+        public init(requests: [Request?]) throws {
+            // we'd like to throw error if we're empty or all are nils
+            // otherwise the 'nil' are as a placeholder for some invalid request.
+            let validatedRequests = requests.compactMap { $0 }
+            if validatedRequests.isEmpty {
+                throw Error(code: -32600, message: "Invalid Request", data: nil)
+            }
+            self.requests = requests
+        }
+    }
+
+    public enum BatchResponse {
+        case response(Response)
+        case array([Response])
+    }
+}
+
+// support for typed params | response results | error data:
+// since all of them are codable, one can encode them and
+// then decode to a typed param in order to not deal with other stuff.
+
+// request encoding/decoding: compiler-generated
+extension JsonRpc2.Request: Codable {}
+
+extension JsonRpc2.Params: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        // encode each associated value
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .array(let value):
+            try container.encode(value)
+        case .object(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+extension JsonRpc2.Params: Decodable {
+    public init(from decoder: Decoder) throws {
+        // try array
+        let container = try decoder.singleValueContainer()
+
+        if let value = try? container.decode(Json.Array.self) {
+            self = .array(value)
+        }
+        // try object
+        else if let value = try? container.decode(Json.Object.self) {
+            self = .object(value)
+        }
+        // fail with error
+        else {
+            let error = DecodingError.typeMismatch(
+                Self.self,
+                DecodingError.Context(codingPath: decoder.codingPath,
+                                      debugDescription: "Unexpected params type",
+                                      underlyingError: nil)
+            )
+            throw error
+        }
+    }
+}
+
+extension JsonRpc2.Id: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        // encode each associated value or null
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .int(let value):
+            try container.encode(value)
+        case .uint(let value):
+            try container.encode(value)
+        case .double(let value):
+            try container.encode(value)
+        case .null:
+            try container.encodeNil()
+        }
+    }
+}
+
+extension JsonRpc2.Id: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        // try int
+        if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        }
+        // try uint
+        else if let value = try? container.decode(UInt.self) {
+            self = .uint(value)
+        }
+        // try double
+        else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        }
+        // try string
+        else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        }
+        // try null
+        else if container.decodeNil() {
+            self = .null
+        }
+        // fail with error
+        else {
+            let error = DecodingError.typeMismatch(
+                Self.self,
+                DecodingError.Context(codingPath: decoder.codingPath,
+                                      debugDescription: "Unexpected id type",
+                                      underlyingError: nil)
+            )
+            throw error
+        }
+    }
+}
+
+// id: comparable
+// only works if both are numbers int uint will be cast to Int(clamping:) and ints will be cast to Double
+// strings are compared only to strings
+// nulls and other combinations return false
+// otherwise they're not comparable (returns false).
+extension JsonRpc2.Id: Comparable {
+    public static func < (lhs: JsonRpc2.Id, rhs: JsonRpc2.Id) -> Bool {
+        switch (lhs, rhs) {
+
+        case let (.int(a), .int(b)):
+            return a < b
+        case let (.int(a), .uint(b)):
+            return a < b
+        case let (.int(a), .double(b)):
+            return Double(a) < b
+
+
+        case let (.uint(a), .uint(b)):
+            return a < b
+        case let (.uint(a), .int(b)):
+            return Int(clamping: a) < b
+        case let (.uint(a), .double(b)):
+            return Double(a) < b
+
+        case let (.string(a), .string(b)):
+            return a < b
+
+        case let (.double(a), .double(b)):
+            return a < b
+        case let (.double(a), .int(b)):
+            return a < Double(b)
+        case let (.double(a), .uint(b)):
+            return a < Double(b)
+
+        case (.null, .null):
+            return false
+
+        default:
+            return false
+        }
+    }
+}
+
+// response encoding/decoding: compiler-generated
+extension JsonRpc2.Response: Codable {}
+
+// error encoding/decoding: compiler-generated
+extension JsonRpc2.Error: Codable {}
+
+extension JsonRpc2.BatchRequest: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(requests)
+    }
+}
+
+extension JsonRpc2.BatchRequest: Decodable {
+    public init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        var requests = [JsonRpc2.Request?]()
+        // try decoding each request and skip the invalid requests
+        if let count = container.count {
+            for _ in (0..<count) {
+                let request: JsonRpc2.Request?
+                do {
+                    request = try container.decode(JsonRpc2.Request.self)
+                } catch {
+                    // error decoding request, it is invalid. We put a placeholder - nil
+                    request = nil
+                    // we must continue, so we should decode a generic json
+                    _ = try container.decode(Json.Element.self)
+                }
+                requests.append(request)
+            }
+        } else {
+            requests = try container.decode([JsonRpc2.Request].self)
+        }
+        try self.init(requests: requests)
+    }
+}
+
+extension JsonRpc2.BatchResponse: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .response(let value):
+            try container.encode(value)
+        case .array(let value):
+            try container.encode(value)
+        }
+    }
+}
+
+extension JsonRpc2.BatchResponse: Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        // try array response
+        if let value = try? container.decode([JsonRpc2.Response].self) {
+            self = .array(value)
+        }
+        // try single response
+        else if let value = try? container.decode(JsonRpc2.Response.self) {
+            self = .response(value)
+        }
+        // fail with error
+        else {
+            let error = DecodingError.typeMismatch(
+                Self.self,
+                DecodingError.Context(codingPath: decoder.codingPath,
+                                      debugDescription: "Unexpected batch response",
+                                      underlyingError: nil)
+            )
+            throw error
+        }
+    }
+}
+
+// default implementation
+extension JsonRpc2.Params: EncodableConvertible, DecodableConvertible {}
+
+
+// utility to create requests and responses for the same rpc call
+public protocol JsonRpc2Method {
+    static var name: String { get }
+    associatedtype Return
+}
+
+extension JsonRpc2Method where Self: Encodable {
+    public func request(id: JsonRpc2.Id? = nil) throws -> JsonRpc2.Request {
+        try JsonRpc2.Request(
+            jsonrpc: "2.0",
+            method: Self.name,
+            params: JsonRpc2.Params(value: self),
+            id: id)
+    }
+}
+
+extension JsonRpc2Method where Return: Decodable {
+    public func result(from element: Json.Element) throws -> Return {
+        try element.convert(to: Return.self)
+    }
+}
+
+
+extension JsonRpc2.Error {
+    // JSON RPC Errors
+    // |       code       |     message      |                      meaning                       |
+    // | ---------------- | ---------------- | -------------------------------------------------- |
+    // | -32700           | Parse error      | Invalid JSON was received by the server.           |
+    // | -32600           | Invalid Request  | The JSON sent is not a valid Request object.       |
+    // | -32601           | Method not found | The method does not exist or is not available.     |
+    // | -32602           | Invalid params   | Invalid method parameter(s).                       |
+    // | -32603           | Internal error   | Internal JSON-RPC error.                           |
+    // | -32000 to -32099 | Server error     | Reserved for implementation-defined server-errors. |
+
+    // Invalid JSON was received by the server.
+    public static let parseError       = JsonRpc2.Error(code: -32700, message: "Parse error", data: nil)
+
+    // The JSON sent is not a valid Request object.
+    public static let invalidRequest   = JsonRpc2.Error(code: -32600, message: "Invalid Request", data: nil)
+
+    // The method does not exist or is not available.
+    public static let methodNotFound   = JsonRpc2.Error(code: -32601, message: "Method not found", data: nil)
+
+    // Invalid method parameter(s).
+    public static let invalidParams    = JsonRpc2.Error(code: -32602, message: "Invalid params", data: nil)
+
+    // Internal JSON-RPC error.
+    public static let internalError    = JsonRpc2.Error(code: -32603, message: "Internal error", data: nil)
+
+    // Reserved for implementation-defined server-errors. Start of the range.
+    public static let serverError00    = JsonRpc2.Error(code: -32000, message: "Server error", data: nil)
+
+    // Reserved for implementation-defined server-errors. End of the range.
+    public static let serverError99    = JsonRpc2.Error(code: -32099, message: "Server error", data: nil)
+}
+
+extension JsonRpc2.Error {
+    public func with(error: Swift.Error) -> JsonRpc2.Error {
+        with(data: Json.NSError(error as NSError).toJson())
+    }
+
+    public func with(data: Json.Element) -> JsonRpc2.Error {
+        var newValue = self
+        newValue.data = data
+        return newValue
+    }
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2.swift
@@ -310,6 +310,10 @@ public protocol JsonRpc2Method {
     associatedtype Return
 }
 
+extension JsonRpc2Method {
+    public static var name: String { String(describing: self) }
+}
+
 extension JsonRpc2Method where Self: Encodable {
     public func request(id: JsonRpc2.Id? = nil) throws -> JsonRpc2.Request {
         try JsonRpc2.Request(

--- a/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2ClientSerializer.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2ClientSerializer.swift
@@ -1,0 +1,14 @@
+//
+//  JsonRpc2ClientSerializer.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+// Responsible for converting something Codable to and from json data
+public protocol JsonRpc2ClientSerializer {
+    func toJson<T: Encodable>(value: T) throws -> Data
+    func fromJson<T: Decodable>(data: Data) throws -> T
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2ClientTransport.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2ClientTransport.swift
@@ -1,0 +1,19 @@
+//
+//  JsonRpc2ClientTransport.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+// Responsible for sending a json data to the Server and receiving response (if any)
+public protocol JsonRpc2ClientTransport {
+    func send(data: Data, completion: @escaping (Result<Data, Error>) -> Void)
+}
+
+@available(iOS 15.0.0, *)
+@available(macOS 12.0.0, *)
+public protocol JsonRpc2ClientAsyncTransport {
+    func send(data: Data) async throws -> Data
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2ClientValidator.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/JsonRpc2ClientValidator.swift
@@ -1,0 +1,17 @@
+//
+//  JsonRpc2ClientValidator.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+// Makes possible to reuse the same client implementation logic for both batch and single rpc requests
+public protocol JsonRpc2ClientValidator {
+    associatedtype Request
+    associatedtype Response
+    func validate(request: Request) throws
+    func validate(response: Response?, for request: Request) throws
+    func error(for request: Request, value: JsonRpc2.Error) -> Response?
+}

--- a/Packages/Ethereum/Sources/JsonRpc2/RequestValidator.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/RequestValidator.swift
@@ -1,0 +1,83 @@
+//
+//  RequestValidator.swift
+//  JsonRpc2
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension JsonRpc2 {
+    public struct RequestValidator: JsonRpc2ClientValidator {
+        public init() {}
+        
+        public func validate(request: JsonRpc2.Request) throws {
+            // jsonrpc: MUST be exactly "2.0"
+            guard request.jsonrpc == "2.0" else {
+                throw JsonRpc2.Error.invalidRequest.with(
+                    data: .string("jsonrpc must be '2.0'. Received: '\(request.jsonrpc)'"))
+            }
+
+            // method:
+            // Method names that begin with the word rpc followed by a period character (U+002E or ASCII 46)
+            // are reserved for rpc-internal methods and extensions and MUST NOT be used for anything else.
+            if request.method.hasPrefix("rpc.") {
+                throw JsonRpc2.Error.invalidRequest.with(
+                    data: .string("method must not start with reserved 'rpc.'. Received: '\(request.jsonrpc)'"))
+            }
+
+            // id:
+            // The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts
+            if request.id == .null {
+                throw JsonRpc2.Error.invalidRequest.with(data: .string("id should not be Null"))
+            }
+
+            if case let .double(value) = request.id, value.truncatingRemainder(dividingBy: 1) != 0 {
+                throw JsonRpc2.Error.invalidRequest.with(data: .string("id should not contain fractional parts"))
+            }
+        }
+
+        public func validate(response: JsonRpc2.Response?, for request: JsonRpc2.Request) throws {
+            // The Server MUST NOT reply to a Notification, including those that are within a batch request.
+            guard let id = request.id else {
+                if response != nil {
+                    throw JsonRpc2.Error.invalidResponse.with(data: .string("server must not reply with response to a notificaiton"))
+                }
+                return
+            }
+
+            guard let response = response else {
+                throw JsonRpc2.Error.invalidResponse.with(data: .string("empty response for a request"))
+            }
+
+            // jsonrpc:
+            // MUST be exactly "2.0".
+            guard response.jsonrpc == "2.0" else {
+                throw JsonRpc2.Error.invalidResponse.with(data: .string("jsonrpc must be '2.0'. Got '\(response.jsonrpc)'"))
+            }
+
+            // id:
+            // It MUST be the same as the value of the id member in the Request Object.
+            // If there was an error in detecting the id in the Request object (e.g. Parse error/Invalid Request), it MUST be Null.
+            guard response.id == .null || response.id == id else {
+                throw JsonRpc2.Error.invalidResponse.with(data: .string("response id '\(response.id)' not matching request id '\(id)'"))
+            }
+
+            // Either the `result` member or `error` member MUST be included, but both members MUST NOT be included.
+            guard response.result == nil && response.error != nil || response.result != nil && response.error == nil else {
+                throw JsonRpc2.Error.invalidResponse.with(data: .string("either 'result' or 'error' must be present but not both."))
+            }
+        }
+
+        public func error(for request: JsonRpc2.Request, value: JsonRpc2.Error) -> JsonRpc2.Response? {
+            // no response object should be returned to the client for notification requests (requests wihtout id)
+            guard let id = request.id else { return nil }
+            // otherwise, return error response
+            return JsonRpc2.Response(
+                jsonrpc: "2.0",
+                result: nil,
+                error: value,
+                id: id)
+        }
+    }
+}

--- a/Packages/Ethereum/Sources/TestHelpers/TestHelpers.swift
+++ b/Packages/Ethereum/Sources/TestHelpers/TestHelpers.swift
@@ -1,0 +1,37 @@
+//
+//  Helper.swift
+//  JsonRpc2Tests
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import Foundation
+
+extension String: LocalizedError {
+    public var errorDescription: String? {
+        self
+    }
+
+    public var localizedDescription: String {
+        self
+    }
+}
+
+public func decode<T: Decodable>(from str: String) throws -> T {
+    guard let data = str.data(using: .utf8) else {
+        throw "Can't encode string to utf8 data"
+    }
+    let decoder = JSONDecoder()
+    let element = try decoder.decode(T.self, from: data)
+    return element
+}
+
+public func encode<T: Encodable>(value: T) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .sortedKeys
+    let data = try encoder.encode(value)
+    guard let string = String(data: data, encoding: .utf8) else {
+        throw "Can't decode json data to utf8 string"
+    }
+    return string
+}

--- a/Packages/Ethereum/Tests/EthereumTests/EthereumTests.swift
+++ b/Packages/Ethereum/Tests/EthereumTests/EthereumTests.swift
@@ -5,5 +5,7 @@ import JsonRpc2
 import Json
 
 final class EthereumTests: XCTestCase {
-    
+    func testName() throws {
+        XCTAssertEqual(EthRpc1.eth_getBalance.name, "eth_getBalance")
+    }
 }

--- a/Packages/Ethereum/Tests/EthereumTests/EthereumTests.swift
+++ b/Packages/Ethereum/Tests/EthereumTests/EthereumTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+@testable import Ethereum
+import TestHelpers
+import JsonRpc2
+import Json
+
+final class EthereumTests: XCTestCase {
+    
+}

--- a/Packages/Ethereum/Tests/JsonRpc2Tests/AsyncClientTests.swift
+++ b/Packages/Ethereum/Tests/JsonRpc2Tests/AsyncClientTests.swift
@@ -1,0 +1,71 @@
+//
+//  AsyncClientTests.swift
+//  JsonRpc2Tests
+//
+//  Created by Dmitry Bespalov on 17.12.21.
+//
+
+import XCTest
+@testable import JsonRpc2
+import TestHelpers
+
+@available(macOS 12.0.0, *)
+class AsyncClientTests: XCTestCase {
+
+    let client = JsonRpc2.AsyncClient(
+        transport: JsonRpc2.AsyncHTTPTransport(url: "https://mainnet.infura.io/v3/PROJECTID"),
+        serializer: JsonRpc2.DefaultSerializer())
+
+    func testSendData() async throws {
+        let request =
+        """
+        {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}
+        """
+
+        print("|>>>", request)
+
+        let input = request.data(using: .utf8)!
+
+        let output = try await client.transport.send(data: input)
+        let response = String(data: output, encoding: .utf8)!
+        print("|<<o", response)
+    }
+
+    func testSendRequest() async throws {
+        let request = JsonRpc2.Request(jsonrpc: "2.0", method: "eth_blockNumber", params: nil, id: .int(1))
+        try print("|>>>", encode(value: request))
+
+        let response = try await client.send(request: request)
+
+        guard let response = response else {
+            XCTFail("nil response")
+            return
+        }
+        guard let result = response.result else {
+            try? print("|<<x", encode(value: response.error!))
+            XCTFail()
+            return
+        }
+
+        let number = try result.convert(to: String.self)
+
+        print("|<<o", number)
+    }
+
+    func testSendBatchRequest() async throws {
+        let request = try JsonRpc2.BatchRequest(requests: [
+            JsonRpc2.Request(jsonrpc: "2.0", method: "eth_blockNumber", params: nil, id: .int(1)),
+            JsonRpc2.Request(jsonrpc: "2.0", method: "eth_blockNumber", params: nil, id: .int(2))
+        ])
+        try print("|>>>", encode(value: request))
+        let response = try await client.send(request: request)
+        switch response {
+        case .response(let response):
+            try? print("|<<x", encode(value: response))
+        case .array(let responses):
+            try? print("|<<o", encode(value: responses))
+        case .none:
+            print("|<<x", "''")
+        }
+    }
+}

--- a/Packages/Ethereum/Tests/JsonRpc2Tests/JsonRpc2ClientTests.swift
+++ b/Packages/Ethereum/Tests/JsonRpc2Tests/JsonRpc2ClientTests.swift
@@ -1,0 +1,105 @@
+//
+//  JsonRpc2ClientTests.swift
+//  JsonRpc2Tests
+//
+//  Created by Dmitry Bespalov on 16.12.21.
+//
+
+import XCTest
+@testable import JsonRpc2
+import TestHelpers
+
+class JsonRpc2ClientTests: XCTestCase {
+    let client = JsonRpc2.Client(
+        transport: JsonRpc2.ClientHTTPTransport(url: "https://mainnet.infura.io/v3/PROJECTID"),
+        serializer: JsonRpc2.DefaultSerializer())
+
+    func testSendData() {
+        let exp = expectation(description: "Request")
+        do {
+            let request =
+            """
+            {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}
+            """
+
+            print("|>>>", request)
+
+            let data = request.data(using: .utf8)!
+
+            client.transport.send(data: data) { result in
+                switch result {
+                case .success(let data):
+                    let response = String(data: data, encoding: .utf8)!
+                    print("|<<o", response)
+
+                case .failure(let error):
+                    print("|<<x", error)
+                    XCTFail()
+                }
+
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+
+    func testSendRequest() throws {
+        let exp = expectation(description: "Request")
+        do {
+            let request = JsonRpc2.Request(jsonrpc: "2.0", method: "eth_blockNumber", params: nil, id: .int(1))
+            try print("|>>>", encode(value: request))
+
+            client.send(request: request) { response in
+                guard let response = response else {
+                    XCTFail("nil response")
+                    exp.fulfill()
+                    return
+                }
+
+                if let result = response.result {
+
+                    do {
+                        let number = try result.convert(to: String.self)
+
+                        print("|<<o", number)
+                    } catch {
+                        XCTFail("Failed to decode: \(result) to String")
+                    }
+
+                } else {
+                    try? print("|<<x", encode(value: response.error!))
+                    XCTFail()
+                }
+
+                exp.fulfill()
+            }
+
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+
+    func testSendBatchRequest() throws {
+        let exp = expectation(description: "Request")
+        do {
+            let request = try JsonRpc2.BatchRequest(requests: [
+                JsonRpc2.Request(jsonrpc: "2.0", method: "eth_blockNumber", params: nil, id: .int(1)),
+                JsonRpc2.Request(jsonrpc: "2.0", method: "eth_blockNumber", params: nil, id: .int(2))
+            ])
+            try print("|>>>", encode(value: request))
+            client.send(request: request) { response in
+
+                switch response {
+                case .response(let response):
+                    try? print("|<<x", encode(value: response))
+                case .array(let responses):
+                    try? print("|<<o", encode(value: responses))
+                case .none:
+                    print("|<<x", "''")
+                }
+
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 300, handler: nil)
+    }
+}

--- a/Packages/Ethereum/Tests/JsonRpc2Tests/JsonRpc2Tests.swift
+++ b/Packages/Ethereum/Tests/JsonRpc2Tests/JsonRpc2Tests.swift
@@ -1,0 +1,190 @@
+//
+//  JsonRpc2Tests.swift
+//  JsonRpc2Tests
+//
+//  Created by Dmitry Bespalov on 15.12.21.
+//
+
+import XCTest
+@testable import JsonRpc2
+import TestHelpers
+
+class JsonRpc2TestCase: XCTestCase {
+
+    func testCodable() throws {
+        // Note: keys are sorted alphabetically in these tests so that the order is deterministic in encoding.
+
+        // rpc call with positional parameters
+        try assert(JsonRpc2.Request.self,
+        """
+        {"id":1,"jsonrpc":"2.0","method":"subtract","params":[42,23]}
+        """)
+
+        try assert(JsonRpc2.Response.self,
+        """
+        {"id":1,"jsonrpc":"2.0","result":19}
+        """
+        )
+
+        // rpc call with named parameters
+        try assert(JsonRpc2.Request.self,
+        """
+        {"id":3,"jsonrpc":"2.0","method":"subtract","params":{"minuend":42,"subtrahend":23}}
+        """
+        )
+
+        // a notification
+        try assert(JsonRpc2.Request.self,
+        """
+        {"jsonrpc":"2.0","method":"update","params":[1,2,3,4,5]}
+        """
+        )
+
+        // a notification
+        try assert(JsonRpc2.Request.self,
+        """
+        {"jsonrpc":"2.0","method":"foobar"}
+        """
+        )
+
+        // error response
+        try assert(JsonRpc2.Response.self,
+        """
+        {"error":{"code":-32601,"message":"Method not found"},"id":"1","jsonrpc":"2.0"}
+        """
+        )
+
+        // invalid request json:
+        XCTAssertThrowsError(
+        try assert(JsonRpc2.Request.self,
+        """
+        {"jsonrpc": "2.0", "method": "foobar, "params": "bar", "baz]
+        """
+        )
+        ) { error in
+            if let err = error as? DecodingError {
+                switch err {
+                case .dataCorrupted(_):
+                    // ok!
+                    break
+                default:
+                    XCTFail("Unexpected error: \(error)")
+                }
+            } else {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        // invalid request (params is primitive)
+        XCTAssertThrowsError(
+        try assert(JsonRpc2.Request.self,
+        """
+        {"jsonrpc": "2.0", "method": 1, "params": "bar"}
+        """
+        )
+        ) { error in
+            if let err = error as? DecodingError {
+                switch err {
+                case .typeMismatch(_, _):
+                    // ok!
+                    break
+                default:
+                    XCTFail("Unexpected error: \(error)")
+                }
+            } else {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testBatch() throws {
+        // rpc call Batch, invalid JSON
+        XCTAssertThrowsError(
+        try assert(JsonRpc2.BatchRequest.self,
+        """
+        [
+          {"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
+          {"jsonrpc": "2.0", "method"
+        ]
+        """
+        )
+        ) { error in
+            if let err = error as? DecodingError {
+                switch err {
+                case .dataCorrupted(_):
+                    // ok!
+                    break
+                default:
+                    XCTFail("Unexpected error: \(error)")
+                }
+            } else {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        // invalid empty batch
+        XCTAssertThrowsError(
+        try assert(JsonRpc2.BatchRequest.self,
+        "[]"
+        )
+        ) { error in
+            if let error = error as? JsonRpc2.Error {
+                XCTAssertEqual(error.code, -32600)
+            }
+        }
+
+        // rpc call with an invalid Batch (but not empty):
+        XCTAssertThrowsError(
+        try assert(JsonRpc2.BatchRequest.self,
+        "[1]"
+        )
+        ) { error in
+            if let error = error as? JsonRpc2.Error {
+                XCTAssertEqual(error.code, -32600)
+            }
+        }
+
+        // rpc call with invalid Batch
+        XCTAssertThrowsError(
+        try assert(JsonRpc2.BatchRequest.self,
+        "[1,2,3]"
+        )
+        ) { error in
+            if let error = error as? JsonRpc2.Error {
+                XCTAssertEqual(error.code, -32600)
+            }
+        }
+
+        // rpc call Batch:
+        let batchWithInvalid: JsonRpc2.BatchRequest = try decode(from:
+        """
+        [
+            {"jsonrpc": "2.0", "method": "sum", "params": [1,2,4], "id": "1"},
+            {"jsonrpc": "2.0", "method": "notify_hello", "params": [7]},
+            {"jsonrpc": "2.0", "method": "subtract", "params": [42,23], "id": "2"},
+            {"foo": "boo"},
+            {"jsonrpc": "2.0", "method": "foo.get", "params": {"name": "myself"}, "id": "5"},
+            {"jsonrpc": "2.0", "method": "get_data", "id": "9"}
+        ]
+        """
+        )
+        try XCTAssertEqual(
+        """
+        [{"id":"1","jsonrpc":"2.0","method":"sum","params":[1,2,4]},{"jsonrpc":"2.0","method":"notify_hello","params":[7]},{"id":"2","jsonrpc":"2.0","method":"subtract","params":[42,23]},null,{"id":"5","jsonrpc":"2.0","method":"foo.get","params":{"name":"myself"}},{"id":"9","jsonrpc":"2.0","method":"get_data"}]
+        """,
+        encode(value: batchWithInvalid))
+
+
+        // rpc response Batch:
+        try assert(JsonRpc2.BatchResponse.self,
+        """
+        [{"id":"1","jsonrpc":"2.0","result":7},{"id":"2","jsonrpc":"2.0","result":19},{"error":{"code":-32600,"message":"Invalid Request"},"id":null,"jsonrpc":"2.0"},{"error":{"code":-32601,"message":"Method not found"},"id":"5","jsonrpc":"2.0"},{"id":"9","jsonrpc":"2.0","result":["hello",5]}]
+        """
+        )
+    }
+
+    func assert<T: Codable>(_ type: T.Type, _ string: String) throws {
+        let request: T = try decode(from: string)
+        try XCTAssertEqual(string, encode(value: request))
+    }
+}

--- a/Packages/Ethereum/Tests/JsonTests/JsonTests.swift
+++ b/Packages/Ethereum/Tests/JsonTests/JsonTests.swift
@@ -1,0 +1,114 @@
+//
+//  JsonTests.swift
+//  JsonRpc2Tests
+//
+//  Created by Dmitry Bespalov on 15.12.21.
+//
+
+import XCTest
+@testable import Json
+import TestHelpers
+import Foundation
+
+class JsonTests: XCTestCase {
+    func testDecoding() throws {
+        try XCTAssertEqual(decode("null"), .null)
+        try XCTAssertEqual(decode("true"), .bool(true))
+        try XCTAssertEqual(decode("false"), .bool(false))
+        try XCTAssertEqual(decode("1"), .int(1))
+        try XCTAssertEqual(decode("0"), .int(0))
+        try XCTAssertEqual(decode("-1"), .int(-1))
+        try XCTAssertEqual(decode("\(UInt.max)"), .uint(UInt.max))
+        try XCTAssertEqual(decode("1.1"), .double(1.1))
+        try XCTAssertEqual(decode("1.0"), .int(1))
+        try XCTAssertEqual(decode("\"hello\""), .string("hello"))
+        try XCTAssertEqual(decode("[]"), .array(Json.Array(elements: [])))
+        try XCTAssertEqual(decode("{}"), .object(Json.Object(members: [:])))
+
+        // array of primitives
+        try XCTAssertEqual(decode("[null, \"hello\", 2, 3.3, -1, true]"),
+                           .array(Json.Array(elements: [.null, .string("hello"), .int(2), .double(3.3), .int(-1), .bool(true)])))
+
+        // array of arrays
+        try XCTAssertEqual(decode("[[],[]]"), .array(Json.Array(elements: [
+            .array(Json.Array(elements: [])),
+            .array(Json.Array(elements: []))
+        ])))
+
+        // array of objects
+        try XCTAssertEqual(decode("[{},{}]"), .array(Json.Array(elements: [
+            .object(Json.Object(members: [:])),
+            .object(Json.Object(members: [:]))
+        ])))
+
+        // object with arrays
+        try XCTAssertEqual(decode("{\"key\": []}"), .object(Json.Object(members: ["key": .array(Json.Array(elements: []))])))
+
+        // object with objects
+        try XCTAssertEqual(decode("{\"key\": {}}"), .object(Json.Object(members: ["key": .object(Json.Object(members: [:]))])))
+    }
+
+    func testEncoding() throws {
+        try XCTAssertEqual("null", encode(.null))
+        try XCTAssertEqual("true", encode(.bool(true)))
+        try XCTAssertEqual("false", encode(.bool(false)))
+        try XCTAssertEqual("1", encode(.int(1)))
+        try XCTAssertEqual("0", encode(.int(0)))
+        try XCTAssertEqual("-1", encode(.int(-1)))
+        try XCTAssertEqual("\(UInt.max)", encode(.uint(UInt.max)))
+        try XCTAssertEqual("1.1000000000000001", encode(.double(1.1)))
+        try XCTAssertEqual("\"hello\"", encode(.string("hello")))
+        try XCTAssertEqual("[]", encode(.array(Json.Array(elements: []))))
+        try XCTAssertEqual("{}", encode(.object(Json.Object(members: [:]))))
+
+        // array of primitives
+        try XCTAssertEqual("[null,\"hello\",2,3.2999999999999998,-1,true]",
+                           encode(
+                           .array(Json.Array(elements: [.null, .string("hello"), .int(2), .double(3.3), .int(-1), .bool(true)]))))
+
+        // array of arrays
+        try XCTAssertEqual("[[],[]]", encode(.array(Json.Array(elements: [
+            .array(Json.Array(elements: [])),
+            .array(Json.Array(elements: []))
+        ]))))
+
+        // array of objects
+        try XCTAssertEqual("[{},{}]", encode(.array(Json.Array(elements: [
+            .object(Json.Object(members: [:])),
+            .object(Json.Object(members: [:]))
+        ]))))
+
+        // object with arrays
+        try XCTAssertEqual("{\"key\":[]}", encode(.object(Json.Object(members: ["key": .array(Json.Array(elements: []))]))))
+
+        // object with objects
+        try XCTAssertEqual("{\"key\":{}}", encode(.object(Json.Object(members: ["key": .object(Json.Object(members: [:]))]))))
+    }
+
+    func testErrorJson() throws {
+        let nsError = NSError(domain: "hello", code: 1, userInfo: [
+            "Hello": 123,
+            NSLocalizedDescriptionKey: "Hello",
+            NSUnderlyingErrorKey: NSError(domain: "my domain", code: 3, userInfo: nil)]
+        )
+        let jsonFromNSError = Json.NSError(nsError)
+        let data = try JSONEncoder().encode(jsonFromNSError)
+
+        let jsonString = String(data: data, encoding: .utf8)!
+        print("|err:", jsonString)
+
+        let jsonErrorFromJson = try JSONDecoder().decode(Json.NSError.self, from: data)
+
+        let nsErrorFromJson = jsonErrorFromJson.nsError()
+
+        XCTAssertEqual(nsError, nsErrorFromJson)
+    }
+
+    func decode(_ str: String) throws -> Json.Element {
+        try TestHelpers.decode(from: str)
+    }
+
+    func encode(_ value: Json.Element) throws -> String {
+        try TestHelpers.encode(value: value)
+    }
+}


### PR DESCRIPTION
Handles #1636 

Changes proposed in this pull request:
- Internal Swift Package
- JSON models
- JSON RPC v2 models, including batch requests
- JSON RPC HTTP-based client
- Ethereum JSON RPC v1 subset of requests and models related to transaction execution:
  - eth_gasPrice
  - eth_call
  - eth_estimateGas
  - eth_sendRawTransaction
  - eth_getTransactionReceipt
  - eth_getBalance
  - eth_getTransactionCount
