### PR TITLE
gh-1804 Fix estimations on different chains

### DIFF
--- a/Multisig/Logic/Models/Chain.swift
+++ b/Multisig/Logic/Models/Chain.swift
@@ -278,7 +278,12 @@ extension Chain {
 
 extension Chain {
     var authenticatedRpcUrl: URL {
-        rpcUrl!.appendingPathComponent(App.configuration.services.infuraKey)
+        switch self.rpcUrlAuthentication {
+        case SCGModels.RpcAuthentication.Authentication.apiKeyPath.rawValue:
+            return rpcUrl!.appendingPathComponent(App.configuration.services.infuraKey)
+        default:
+            return rpcUrl!
+        }
     }
 
     var textColor: UIColor? {

--- a/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
@@ -52,7 +52,7 @@ class TransactionExecutionController {
         self.safe = safe
         self.chain = chain
         self.transaction = transaction
-        self.estimationController = TransactionEstimationController(rpcUri: chain.authenticatedRpcUrl.absoluteString)
+        self.estimationController = TransactionEstimationController(rpcUri: chain.authenticatedRpcUrl.absoluteString, chain: chain)
     }
 
     // returns the execution keys valid for executing this transaction

--- a/Packages/Ethereum/Sources/JsonRpc2/Client.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/Client.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Json
 
 extension JsonRpc2 {
     // The Client is defined as the origin of Request objects and the handler of Response objects.
@@ -88,7 +89,12 @@ extension JsonRpc2 {
                     do {
                         response = try serializer.fromJson(data: jsonResponse)
                     } catch let swiftDecodingError {
-                        completion(validator.error(for: request, value: .parseResponseError.with(error: swiftDecodingError)))
+                        let jsonString = String(data: jsonResponse, encoding: .utf8) ?? "<n/a>"
+                        let data = Json.Element.object(Json.Object(members: [
+                            "response": Json.Element.string(jsonString),
+                            "swiftError": Json.NSError(swiftDecodingError as NSError).toJson()
+                        ]))
+                        completion(validator.error(for: request, value: .parseResponseError.with(data: data)))
                         return
                     }
 

--- a/Packages/Ethereum/Sources/JsonRpc2/ClientHTTPTransport.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/ClientHTTPTransport.swift
@@ -24,6 +24,10 @@ extension JsonRpc2 {
             urlRequest.httpMethod = "POST"
             urlRequest.httpBody = data
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            urlRequest.setValue("\(data.count)", forHTTPHeaderField: "Content-Length")
+
+            print("JsonRpc2 >>>", urlRequest)
+            print("JsonRpc2 >>>", String(data: data, encoding: .utf8) ?? "''")
 
             let dataTask = URLSession.shared.dataTask(with: urlRequest) { dataOrNil, _, errorOrNil in
                 // From the docs:


### PR DESCRIPTION
Handles #1804 

Changes proposed in this pull request:
- Fixes for chain-specific estimation failures

- xDAI, Energy Web Chain, Volta: the `eth_estimateGas()` expected different transaction parameter than on other networks. Perhaps it is related to the RPC client that is used there. Maybe it is outdated. I created a special rpc request with the required parameter fields just for those networks.
- BSC: the HTTP POST response was missing `Content-Length` header
- Optimism, BSC: uses not authenticated rpc URL but implementation was passing an API key.
- Added `print` to console to show the json rpc2 requests for now. Proper logging after release. 🤞 
