### PR TITLE
gh-1804 Using legacy estimation apis for some chains

### DIFF
--- a/Multisig/UI/Transaction/Execution/TransactionEstimationController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionEstimationController.swift
@@ -20,6 +20,12 @@ class TransactionEstimationController {
         "246",
         // Volta
         "73799",
+        // arbitrm one
+        "42161",
+        // binance smart chain
+        "56",
+        // optimism
+        "10",
     ]
 
     let rpcClient: JsonRpc2.Client

--- a/Packages/Ethereum/Sources/JsonRpc2/ClientHTTPTransport.swift
+++ b/Packages/Ethereum/Sources/JsonRpc2/ClientHTTPTransport.swift
@@ -36,6 +36,9 @@ extension JsonRpc2 {
                 //
                 // If the request fails, the data parameter is nil and the error parameter
                 // contain information about the failure.
+                if let dataOrNil = dataOrNil, let str = String(data: dataOrNil, encoding: .utf8) {
+                    print("JsonRpc2 <<<", str)
+                }
                 if let data = dataOrNil, errorOrNil == nil {
                     completion(.success(data))
                 } else if let error = errorOrNil {


### PR DESCRIPTION
Handles #1804 

Changes proposed in this pull request:
- After using the 'legacy' estimation API the transactions went through

NOTE: this doesn't depend on whether the chain supports EIP-1559 or not, it seems to depend on the RPC client that we're getting to use.