### PR TITLE
GH-1696: Intercom can't be opened after calling app from background -> main

### DIFF
--- a/Multisig/App/SceneDelegate.swift
+++ b/Multisig/App/SceneDelegate.swift
@@ -87,6 +87,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         if presentedWindow === tabBarWindow {
             privacyShieldWindow?.isHidden = false
         }
+        App.shared.intercomConfig.hide()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/Multisig/Cross-layer/Configuration/IntercomConfig.swift
+++ b/Multisig/Cross-layer/Configuration/IntercomConfig.swift
@@ -29,6 +29,10 @@ class IntercomConfig {
         Intercom.presentMessenger()
     }
 
+    func hide() {
+        Intercom.hide()
+    }
+
     func appDidShowMainContent() {
         // adding delay hack to handle the case when this shows right after app start -  in that case we would see the
         // black window background behind the intercom window. We give the app time to initialize.

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -68,6 +68,16 @@ class MainTabBarViewController: UITabBarController {
             selector: #selector(updateTabs),
             name: .updatedExperemental,
             object: nil)
+
+        NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(appMovedToBackground),
+                name: UIApplication.willResignActiveNotification,
+                object: nil)
+    }
+
+    @objc func appMovedToBackground() {
+        App.shared.intercomConfig.hide()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -68,16 +68,6 @@ class MainTabBarViewController: UITabBarController {
             selector: #selector(updateTabs),
             name: .updatedExperemental,
             object: nil)
-
-        NotificationCenter.default.addObserver(
-                self,
-                selector: #selector(appMovedToBackground),
-                name: UIApplication.willResignActiveNotification,
-                object: nil)
-    }
-
-    @objc func appMovedToBackground() {
-        App.shared.intercomConfig.hide()
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Handles #1696 #1697

Hide Intercom when ging to background. There is no way to check whether it is open and that check also seems unnecessary. hide() works either way.

Changes proposed in this pull request:
- hide() Intercom when going to background. Whether it is open or not.

