### PR TITLE
gh-1869 Check for failing tx before executing it

### DIFF
--- a/Multisig/UI/Transaction/Execution/TransactionEstimationController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionEstimationController.swift
@@ -36,7 +36,7 @@ class TransactionEstimationController {
         self.rpcClient = JsonRpc2.Client(transport: JsonRpc2.ClientHTTPTransport(url: rpcUri), serializer: JsonRpc2.DefaultSerializer())
     }
 
-    typealias EstimateCompletion = (Result<(gas: Result<Sol.UInt64, Error>, transactionCount: Result<Sol.UInt64, Error>, gasPrice: Result<Sol.UInt256, Error>), Error>) -> Void
+    typealias EstimateCompletion = (Result<(gas: Result<Sol.UInt64, Error>, transactionCount: Result<Sol.UInt64, Error>, gasPrice: Result<Sol.UInt256, Error>, ethCall: Result<Data, Error>), Error>) -> Void
 
     func estimateTransactionWithRpc(tx: EthTransaction, completion: @escaping EstimateCompletion) -> URLSessionTask? {
         // check if we have hint from the chain configuration about the gas price. For now support only fixed.
@@ -61,19 +61,23 @@ class TransactionEstimationController {
 
         let getPrice = EthRpc1.eth_gasPrice()
 
+        let ethCall = EthRpc1.eth_call(transaction: EthRpc1.Transaction(tx), block: .tag(.pending))
+
         let batch: JsonRpc2.BatchRequest
         let getEstimateRequest: JsonRpc2.Request
         let getTransactionCountRequest: JsonRpc2.Request
         let getPriceRequest: JsonRpc2.Request
+        let ethCallRequest: JsonRpc2.Request
 
 
         do {
             getEstimateRequest = try usingLegacyGasApi ? getEstimateLegacy.request(id: .int(1)) : getEstimateNew.request(id: .int(1))
             getTransactionCountRequest = try getTransactionCount.request(id: .int(2))
             getPriceRequest = try getPrice.request(id: .int(3))
+            ethCallRequest = try ethCall.request(id: .int(4))
 
             batch = try JsonRpc2.BatchRequest(requests: [
-                getEstimateRequest, getTransactionCountRequest, getPriceRequest
+                getEstimateRequest, getTransactionCountRequest, getPriceRequest, ethCallRequest
             ])
         } catch {
             dispatchOnMainThread(completion(.failure(error)))
@@ -118,8 +122,9 @@ class TransactionEstimationController {
                     : result(request: getEstimateRequest, method: getEstimateNew, responses: responses).map(\.storage)
                 let txCountResult = result(request: getTransactionCountRequest, method: getTransactionCount, responses: responses).map(\.storage)
                 let priceResult = fixedGasPrice.map { .success($0) } ?? result(request: getPriceRequest, method: getPrice, responses: responses).map(\.storage)
+                let callResult = result(request: ethCallRequest, method: ethCall, responses: responses).map(\.storage)
 
-                dispatchOnMainThread(completion(.success((gasResult, txCountResult, priceResult))))
+                dispatchOnMainThread(completion(.success((gasResult, txCountResult, priceResult, callResult))))
             }
         }
         return task


### PR DESCRIPTION
Handles #1869 

Changes proposed in this pull request:
- Using eth_call during transaction estimation
- Decoding the result and checking if it was successful.

