### PR TITLE
gh-1886 Only check when there's something returned from the call

### DIFF
--- a/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
@@ -214,9 +214,11 @@ class TransactionExecutionController {
                     gas = try partialResults.gas.get()
 
                     let execTransactionSuccess = try partialResults.ethCall.get()
-                    let success = try Sol.Bool(execTransactionSuccess).storage
-                    guard success else {
-                        throw TransactionExecutionError(code: -7, message: "Internal Gnosis Safe transaction fails. Please double check whether this transaction is valid with the current state of the Safe.")
+                    if !execTransactionSuccess.isEmpty {
+                        let success = try Sol.Bool(execTransactionSuccess).storage
+                        guard success else {
+                            throw TransactionExecutionError(code: -7, message: "Internal Gnosis Safe transaction fails. Please double check whether this transaction is valid with the current state of the Safe.")
+                        }
                     }
                 } catch {
                     errors.append(error)


### PR DESCRIPTION
Handles #1886 

Changes proposed in this pull request:
- Check for eth_call result only if something is returned
