### PR TITLE
gh-1886 using legacy tx data format

### DIFF
--- a/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
@@ -214,11 +214,9 @@ class TransactionExecutionController {
                     gas = try partialResults.gas.get()
 
                     let execTransactionSuccess = try partialResults.ethCall.get()
-                    if !execTransactionSuccess.isEmpty {
-                        let success = try Sol.Bool(execTransactionSuccess).storage
-                        guard success else {
-                            throw TransactionExecutionError(code: -7, message: "Internal Gnosis Safe transaction fails. Please double check whether this transaction is valid with the current state of the Safe.")
-                        }
+                    let success = try Sol.Bool(execTransactionSuccess).storage
+                    guard success else {
+                        throw TransactionExecutionError(code: -7, message: "Internal Gnosis Safe transaction fails. Please double check whether this transaction is valid with the current state of the Safe.")
                     }
                 } catch {
                     errors.append(error)


### PR DESCRIPTION
Handles #1886 

Changes proposed in this pull request:
- Revert previous fix
- Use 'legacy' tx format. The eth_call was failing because the API did not expect to see 'chainId' and other parameters. When executed on EWT this received proper error response. I'm reusing the same format that worked for estimating gas.