### PR TITLE
gh-1924 Fix long key name display in WebConnectionOwnerView

### DIFF
--- a/Multisig/UI/UI Library/Views/WebConnectionOwnerView.swift
+++ b/Multisig/UI/UI Library/Views/WebConnectionOwnerView.swift
@@ -19,6 +19,7 @@ class WebConnectionOwnerView: UINibView {
         backgroundView.layer.cornerRadius = 4
         backgroundView.clipsToBounds = true
         keyLabel.setStyle(.footnote2)
+        keyLabel.lineBreakMode = .byTruncatingMiddle
     }
     
     func set(name: String, address: Address) {


### PR DESCRIPTION
Handles #1924

Changes proposed in this pull request:
- Ellipsize in the middle

