### PR TITLE
gh-1939 Bump build number

### DIFF
--- a/Multisig/Info.plist
+++ b/Multisig/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.8.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/MultisigIntegrationTests/Info.plist
+++ b/MultisigIntegrationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/MultisigTests/Info.plist
+++ b/MultisigTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.0</string>
+	<string>3.8.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>NSExtension</key>


### PR DESCRIPTION
Handles #1939 

Changes proposed in this pull request:
- Bump main's number to 3.8.0
- Release branch stays at 3.7.0 version number
