### PR TITLE
gh-1990 Deploying state for safe item

### DIFF
--- a/Multisig/UI/App/HeaderViewController/SafeBarView.swift
+++ b/Multisig/UI/App/HeaderViewController/SafeBarView.swift
@@ -42,7 +42,11 @@ class SafeBarView: UINibView {
         self.address = value
         self.prefix = prefix
         self.isDeploying = isDepolying
-        identiconView.setAddress(value.hexadecimal)
+        if isDepolying {
+            identiconView.setAddressGrayscale(value.hexadecimal)
+        } else {
+            identiconView.setAddress(value.hexadecimal)
+        }
         displayAddress()
     }
 

--- a/Multisig/UI/Safe Management/SwitchSafesViewController/SafeEntryTableViewCell.swift
+++ b/Multisig/UI/Safe Management/SwitchSafesViewController/SafeEntryTableViewCell.swift
@@ -13,16 +13,25 @@ class SafeEntryTableViewCell: UITableViewCell {
     @IBOutlet private weak var mainLabel: UILabel!
     @IBOutlet private weak var detailLabel: UILabel!
     @IBOutlet private weak var selectorView: UIImageView!
-
+    @IBOutlet weak var progressIndicator: UIActivityIndicatorView!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         mainLabel.setStyle(.headline)
         detailLabel.setStyle(.tertiary)
     }
 
-    func setAddress(_ value: Address, prefix: String? = nil) {
-        mainImageView.setAddress(value.hexadecimal)
-        detailLabel.text = prefixString(prefix: prefix) + value.ellipsized()
+    func setAddress(_ value: Address, prefix: String? = nil, deploying: Bool = false) {
+      
+        if deploying {
+            progressIndicator.isHidden = false
+            mainImageView.setAddressGrayscale(value.hexadecimal)
+            detailLabel.text = "Creating in progress..."
+        } else {
+            progressIndicator.isHidden = true
+            mainImageView.setAddress(value.hexadecimal)
+            detailLabel.text = prefixString(prefix: prefix) + value.ellipsized()
+        }
     }
 
     func setName(_ value: String) {

--- a/Multisig/UI/Safe Management/SwitchSafesViewController/SafeEntryTableViewCell.xib
+++ b/Multisig/UI/Safe Management/SwitchSafesViewController/SafeEntryTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -26,22 +26,25 @@
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="4nS-eF-yo0">
-                        <rect key="frame" x="64" y="12.5" width="204" height="41"/>
+                        <rect key="frame" x="64" y="12.5" width="168" height="41"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MIc-5I-mGm">
-                                <rect key="frame" x="0.0" y="0.0" width="204" height="20.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="168" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XnQ-qz-rsE">
-                                <rect key="frame" x="0.0" y="20.5" width="204" height="20.5"/>
+                                <rect key="frame" x="0.0" y="20.5" width="168" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                     </stackView>
+                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="sWA-tw-6Ow">
+                        <rect key="frame" x="244" y="23" width="20" height="20"/>
+                    </activityIndicatorView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="checkmark" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="sD6-ay-hF7">
                         <rect key="frame" x="280" y="23" width="24" height="20.5"/>
                         <color key="tintColor" name="button"/>
@@ -52,10 +55,12 @@
                     </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="sD6-ay-hF7" firstAttribute="leading" secondItem="4nS-eF-yo0" secondAttribute="trailing" constant="12" id="35T-2B-NUx"/>
                     <constraint firstItem="uCU-XK-SxW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="5EO-nj-OkZ"/>
+                    <constraint firstItem="sWA-tw-6Ow" firstAttribute="leading" secondItem="4nS-eF-yo0" secondAttribute="trailing" constant="12" id="7ec-oX-Ojs"/>
                     <constraint firstItem="sD6-ay-hF7" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Dkw-9U-91R"/>
+                    <constraint firstItem="sD6-ay-hF7" firstAttribute="leading" secondItem="sWA-tw-6Ow" secondAttribute="trailing" constant="16" id="Hsv-wH-Lhk"/>
                     <constraint firstItem="4nS-eF-yo0" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="LYz-Qd-dAx"/>
+                    <constraint firstItem="sWA-tw-6Ow" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Smf-7V-YC9"/>
                     <constraint firstItem="uCU-XK-SxW" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="iLv-uv-2md"/>
                     <constraint firstItem="4nS-eF-yo0" firstAttribute="leading" secondItem="uCU-XK-SxW" secondAttribute="trailing" constant="12" id="lzm-mC-6Wj"/>
                     <constraint firstAttribute="trailing" secondItem="sD6-ay-hF7" secondAttribute="trailing" constant="16" id="nf0-zx-p0y"/>
@@ -66,6 +71,7 @@
                 <outlet property="detailLabel" destination="XnQ-qz-rsE" id="L3l-Te-oxH"/>
                 <outlet property="mainImageView" destination="uCU-XK-SxW" id="HVa-Zt-xLq"/>
                 <outlet property="mainLabel" destination="MIc-5I-mGm" id="R6A-jj-r6N"/>
+                <outlet property="progressIndicator" destination="sWA-tw-6Ow" id="KLV-dz-ak8"/>
                 <outlet property="selectorView" destination="sD6-ay-hF7" id="XNK-ob-Oa1"/>
             </connections>
             <point key="canvasLocation" x="141" y="154"/>

--- a/Multisig/UI/Safe Management/SwitchSafesViewController/SwitchSafesViewController.swift
+++ b/Multisig/UI/Safe Management/SwitchSafesViewController/SwitchSafesViewController.swift
@@ -80,7 +80,7 @@ final class SwitchSafesViewController: UITableViewController {
         let cell = tableView.dequeueReusableCell(withIdentifier: "SafeEntry", for: indexPath) as! SafeEntryTableViewCell
         let safe = chainSafes[indexPath.section - 1].safes[indexPath.row]
         cell.setName(safe.displayName)
-        cell.setAddress(safe.addressValue, prefix: safe.chain!.shortName)
+        cell.setAddress(safe.addressValue, prefix: safe.chain!.shortName, deploying: safe.safeStatus != .deployed)
         cell.setSelection(safe.isSelected)
         return cell
     }

--- a/Multisig/UI/UI Library/UIImageViewExtensions.swift
+++ b/Multisig/UI/UI Library/UIImageViewExtensions.swift
@@ -18,6 +18,16 @@ extension UIImageView {
         let provider = BlockiesImageProvider(seed: value, width: width, height: height)
         let processor = RoundCornerImageProcessor(radius: .widthFraction(0.5))
         kf.setImage(with: provider, options: [.processor(processor)])
+        self.alpha = 1.0
+    }
+    
+    /// Sets the image to a blockies pattern generated from the `value`.
+    /// - Parameter value: address to use. Must be hexadecimal and lowercased.
+    func setAddressGrayscale(_ value: String, width: CGFloat = 250, height: CGFloat = 250) {
+        let provider = BlockiesImageProvider(seed: value, width: width, height: height)
+        let processor = RoundCornerImageProcessor(radius: .widthFraction(0.5)) |> BlackWhiteProcessor()
+        kf.setImage(with: provider, options: [.processor(processor)])
+        self.alpha = 0.3
     }
 
     /// Loads the image from URL or sets a placeholder image instead.


### PR DESCRIPTION
Handles #1990

Changes proposed in this pull request:
- Add ImageView extension for showing grayscaled blockies
- Add progress indicator to safe item in safe selection list for safes that are being deployed
- Show grayscaled blockies for safe that are being deployed in safe selection list and SafeBarView

<img width="680" alt="image" src="https://user-images.githubusercontent.com/17750984/156154525-1f62914a-1592-4d4f-9ef0-2560945ee5e3.png">

![image](https://user-images.githubusercontent.com/17750984/156159380-35a8dfe6-0fc0-4e2a-93d1-b77e7da00e3c.png)



