### PR TITLE
GH-2053 Wallet Connection Details

### DIFF
--- a/Multisig/Features/Connect to Web/Logic/WebConnectionController.swift
+++ b/Multisig/Features/Connect to Web/Logic/WebConnectionController.swift
@@ -362,7 +362,11 @@ class WebConnectionController: ServerDelegateV2, RequestHandler, WebConnectionSu
     // MARK: - Managing WebConnection
 
     func connections() -> [WebConnection] {
-        connectionRepository.connections()
+        connectionRepository.connections().filter { connection in
+            connection.localPeer?.role == .wallet &&
+            connection.remotePeer?.peerType == .gnosisSafeWeb &&
+            connection.remotePeer?.role == .dapp
+        }
     }
 
     func connection(for session: Session) -> WebConnection? {

--- a/Multisig/Features/Connect to Web/Logic/WebConnectionController.swift
+++ b/Multisig/Features/Connect to Web/Logic/WebConnectionController.swift
@@ -867,6 +867,13 @@ class WebConnectionController: ServerDelegateV2, RequestHandler, WebConnectionSu
 
     // MARK: - Connect Wallet Logic
 
+    func walletConnection(keyInfo: KeyInfo) -> [WebConnection] {
+        let result = connectionRepository.connections(account: keyInfo.address).filter { connection in
+            connection.localPeer?.role == .dapp && connection.remotePeer?.role == .wallet
+        }
+        return result
+    }
+
     // create connection to a wallet
     func connect(wallet info: WCAppRegistryEntry, chainId: Int?) throws -> WebConnection {
         let handshakeTopic = UUID().uuidString

--- a/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
@@ -194,7 +194,12 @@ class WebConnectionDetailsViewController: UITableViewController, WebConnectionOb
             cell.padding = 16
             cell.backgroundColor = .clear
             cell.setText("Disconnect", style: .filledError) { [unowned self] in
-                let alertController = DisconnectionConfirmationController.create(connection: connection)
+                var alertController: DisconnectionConfirmationController
+                if let keyInfo = key  {
+                    alertController = DisconnectionConfirmationController.create(key: keyInfo)
+                } else {
+                    alertController = DisconnectionConfirmationController.create(connection: connection)
+                }
                 self.present(alertController, animated: true)
             }
             return cell

--- a/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
@@ -8,7 +8,10 @@ import UIKit
 class WebConnectionDetailsViewController: UITableViewController, WebConnectionObserver {
 
     var connection: WebConnection!
-    var peer: GnosisSafeWebPeerInfo!
+    var peer: WebConnectionPeerInfo!
+    var safeWebPeer: GnosisSafeWebPeerInfo? {
+        peer as? GnosisSafeWebPeerInfo
+    }
     var chain: Chain!
     var key: KeyInfo?
     var rows: [RowType] = []
@@ -54,15 +57,16 @@ class WebConnectionDetailsViewController: UITableViewController, WebConnectionOb
         chain = connection.chainId.map(String.init).map(Chain.by(_:)) ?? Chain.mainnetChain()
         key = try? connection.accounts.first.flatMap(KeyInfo.firstKey(address:))
         assert(connection.remotePeer != nil)
-        assert(connection.remotePeer is GnosisSafeWebPeerInfo)
-        peer = connection.remotePeer as? GnosisSafeWebPeerInfo
+        peer = connection.remotePeer
 
         rows = [.header, .key, .network]
-        if peer.appVersion != nil && peer.browser != nil {
+
+        if let peer = safeWebPeer, peer.appVersion != nil && peer.browser != nil {
             rows.append(contentsOf: [.version, .browser])
         } else {
             rows.append(.description)
         }
+
         rows.append(.expirationDate)
         rows.append(.button)
         tableView.reloadData()
@@ -147,14 +151,14 @@ class WebConnectionDetailsViewController: UITableViewController, WebConnectionOb
         case .version:
             let cell = contentCell()
             cell.setText("Version")
-            let text = peer.appVersion ?? "Unknown"
+            let text = safeWebPeer?.appVersion ?? "Unknown"
             cell.setContent(textView(text))
             return cell
 
         case .browser:
             let cell = contentCell()
             cell.setText("Browser")
-            let text = peer.browser ?? "Unknown"
+            let text = safeWebPeer?.browser ?? "Unknown"
             cell.setContent(textView(text))
             return cell
 

--- a/Multisig/Logic/Models/KeyInfo.swift
+++ b/Multisig/Logic/Models/KeyInfo.swift
@@ -41,7 +41,15 @@ extension KeyInfo {
     }
 
     var connected: Bool {
-        keyType == .walletConnect && wallet != nil && (connections?.anyObject() ?? nil) != nil
+        guard keyType == .walletConnect, let connections = connections else { return false }
+        let walletConnections = connections
+                .compactMap { $0 as? CDWCConnection }
+                .filter {
+                    $0.localPeer?.role == WebConnectionPeerRole.dapp.rawValue &&
+                            $0.remotePeer?.role == WebConnectionPeerRole.wallet.rawValue
+                }
+        let result = !walletConnections.isEmpty
+        return result
     }
 
     struct WalletConnectKeyMetadata: Codable {

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/KeyTypeTableViewCell.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/KeyTypeTableViewCell.swift
@@ -12,6 +12,7 @@ class KeyTypeTableViewCell: UITableViewCell {
     @IBOutlet private weak var imageContainerView: UIView!
     @IBOutlet private weak var iconImageView: UIImageView!
     @IBOutlet private weak var nameLabel: UILabel!
+    @IBOutlet private weak var disclosure: UIImageView!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -27,5 +28,9 @@ class KeyTypeTableViewCell: UITableViewCell {
     func set(name: String, iconName: String) {
         nameLabel.text = name
         iconImageView.image = UIImage(named: iconName)
+    }
+
+    func setDisclosureImage(_ image: UIImage?) {
+        disclosure.image = image
     }
 }

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/KeyTypeTableViewCell.xib
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/KeyTypeTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="50" id="KGk-i7-Jjw" customClass="KeyTypeTableViewCell" customModule="Multisig" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
@@ -44,6 +44,13 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="arrow" translatesAutoresizingMaskIntoConstraints="NO" id="MCe-8E-aqC">
+                        <rect key="frame" x="280" y="-2" width="40" height="60"/>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="40" id="VMx-iF-bgM"/>
+                            <constraint firstAttribute="width" constant="40" id="tjV-sE-JwO"/>
+                        </constraints>
+                    </imageView>
                 </subviews>
                 <color key="backgroundColor" name="secondaryBackground"/>
                 <constraints>
@@ -51,12 +58,16 @@
                     <constraint firstAttribute="trailing" secondItem="TWe-6v-EcN" secondAttribute="trailing" constant="16" id="O7Q-f5-qxX"/>
                     <constraint firstItem="x7B-Qc-KdT" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="a9z-hf-pdC"/>
                     <constraint firstItem="x7B-Qc-KdT" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="i8P-ld-whn"/>
+                    <constraint firstItem="MCe-8E-aqC" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="ohb-bI-goA"/>
+                    <constraint firstAttribute="trailing" secondItem="MCe-8E-aqC" secondAttribute="trailing" id="q5J-ec-DDb"/>
                     <constraint firstItem="TWe-6v-EcN" firstAttribute="leading" secondItem="x7B-Qc-KdT" secondAttribute="trailing" constant="16" id="rBw-3U-2a8"/>
+                    <constraint firstAttribute="bottom" secondItem="MCe-8E-aqC" secondAttribute="bottom" id="tpX-SY-71p"/>
                     <constraint firstAttribute="bottom" secondItem="x7B-Qc-KdT" secondAttribute="bottom" constant="12" id="vCd-Dq-Gj8"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="disclosure" destination="MCe-8E-aqC" id="QqE-nz-iNa"/>
                 <outlet property="iconImageView" destination="Q7v-KK-4rw" id="snl-ps-TdN"/>
                 <outlet property="imageContainerView" destination="x7B-Qc-KdT" id="hJV-w1-Et9"/>
                 <outlet property="nameLabel" destination="TWe-6v-EcN" id="VKH-Vo-Olp"/>
@@ -65,6 +76,7 @@
         </tableViewCell>
     </objects>
     <resources>
+        <image name="arrow" width="40" height="60"/>
         <namedColor name="secondaryBackground">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -27,6 +27,8 @@ class OwnerKeyDetailsViewController: UITableViewController {
     private var sections = [SectionItems]()
     private var addKeyController: DelegateKeyController!
 
+    private var connection: WebConnection!
+
     enum Section {
         case name(String)
         case keyAddress(String)
@@ -70,6 +72,13 @@ class OwnerKeyDetailsViewController: UITableViewController {
         self.init()
         self.keyInfo = keyInfo
         self.completion = completion
+
+        //TODO: Remove and use keyInfo.connection
+        let controller = WebConnectionController()
+        let url = WebConnectionURL(wcURL: WCURL(topic: UUID().uuidString, version: "1", bridgeURL: URL(string: "https://example.org")!, key: UUID().uuidString))
+        let connection = controller.createConnection(from: url)
+
+        self.connection = connection // TODO: Use keyInfo.connection or keyInfo.connection[0]
     }
 
     override func loadView() {
@@ -221,7 +230,7 @@ class OwnerKeyDetailsViewController: UITableViewController {
     }
 
     private func reconnectKey() {
-        assert(keyInfo.keyType == .walletConnect, "Developer error: worng key type used")
+        assert(keyInfo.keyType == .walletConnect, "Developer error: wrong key type used")
 
         if let installedWallet = keyInfo.installedWallet {
             guard let topic = WalletConnectClientController.reconnectWithInstalledWallet(installedWallet) else { return }
@@ -233,7 +242,7 @@ class OwnerKeyDetailsViewController: UITableViewController {
     }
 
     private func disconnectKey() {
-        assert(keyInfo.keyType == .walletConnect, "Developer error: worng key type used")
+        assert(keyInfo.keyType == .walletConnect, "Developer error: wrong key type used")
         guard WalletConnectClientController.shared.isConnected(keyInfo: keyInfo) else { return }
         WalletConnectClientController.shared.disconnect()
     }
@@ -367,6 +376,11 @@ class OwnerKeyDetailsViewController: UITableViewController {
                 App.shared.snackbar.show(message: error.localizedDescription)
             }
             return
+        case Section.OwnerKeyType.type:
+            let detailsVC = WebConnectionDetailsViewController()
+            detailsVC.connection = connection
+            let vc = ViewControllerFactory.modal(viewController: detailsVC)
+            present(vc, animated: true)
         default:
             break
         }

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -312,6 +312,9 @@ class OwnerKeyDetailsViewController: UITableViewController {
         case Section.KeyAddress.address:
             return tableView.addressDetailsCell(address: keyInfo.address, showQRCode: true, indexPath: indexPath)
         case Section.OwnerKeyType.type:
+            if keyInfo.keyType == .walletConnect {
+                // TODO: show chevron
+            }
             return keyTypeCell(type: keyInfo.keyType, indexPath: indexPath)
         case Section.Connected.connected:
             return tableView.switchCell(for: indexPath,
@@ -377,10 +380,12 @@ class OwnerKeyDetailsViewController: UITableViewController {
             }
             return
         case Section.OwnerKeyType.type:
-            let detailsVC = WebConnectionDetailsViewController()
-            detailsVC.connection = connection
-            let vc = ViewControllerFactory.modal(viewController: detailsVC)
-            present(vc, animated: true)
+            if keyInfo.keyType == .walletConnect {
+                let detailsVC = WebConnectionDetailsViewController()
+                detailsVC.connection = connection
+                let vc = ViewControllerFactory.modal(viewController: detailsVC)
+                present(vc, animated: true)
+            }
         default:
             break
         }

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -382,7 +382,10 @@ class OwnerKeyDetailsViewController: UITableViewController {
         case Section.OwnerKeyType.type:
             if keyInfo.keyType == .walletConnect {
                 let detailsVC = WebConnectionDetailsViewController()
-                detailsVC.connection = connection
+                guard let webConnection = WebConnectionController.shared.walletConnection(keyInfo: keyInfo).first else {
+                    return
+                }
+                detailsVC.connection = webConnection
                 let vc = ViewControllerFactory.modal(viewController: detailsVC)
                 present(vc, animated: true)
             }

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -312,9 +312,6 @@ class OwnerKeyDetailsViewController: UITableViewController {
         case Section.KeyAddress.address:
             return tableView.addressDetailsCell(address: keyInfo.address, showQRCode: true, indexPath: indexPath)
         case Section.OwnerKeyType.type:
-            if keyInfo.keyType == .walletConnect {
-                // TODO: show chevron
-            }
             return keyTypeCell(type: keyInfo.keyType, indexPath: indexPath)
         case Section.Connected.connected:
             return tableView.switchCell(for: indexPath,
@@ -340,6 +337,9 @@ class OwnerKeyDetailsViewController: UITableViewController {
     private func keyTypeCell(type: KeyType, indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueCell(KeyTypeTableViewCell.self, for: indexPath)
         cell.set(name: type.name, iconName: type.imageName)
+        if type != .walletConnect {
+            cell.setDisclosureImage(nil)
+        }
         cell.selectionStyle = .none
         return cell
     }


### PR DESCRIPTION
Handles #2053 

Changes proposed in this pull request:
- Navigate to connection details from Owner Key details if key type is wallet connect
- Show chevron to indicate navigation to connection details

**Missing** Postponed to #2091
- Show network below key in key list

WalletConnect Owner Key | Connection Details
-------------------------- | -------------------
![image](https://user-images.githubusercontent.com/246473/158965246-85f32695-fbfb-4894-a32e-8ffee3be54bc.png) | ![image](https://user-images.githubusercontent.com/246473/158965203-d8f6914c-cae4-4ac6-a74d-60d6ae2a78cb.png)
