### PR TITLE
gh-2052 Fixes connection uri

### DIFF
--- a/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "78f7087fd5d48eb7c36e299f330b6dddccd647b2",
-          "version": "8.12.1"
+          "revision": "d4c4e8c7b8898ea771e90beab71112ea279d73a5",
+          "version": "8.13.0"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "0c02c46cfdc0656ce74fd0963a75e5000a0b7f23",
-          "version": "7.1.2"
+          "revision": "32e4acdf6971f58f5ad552389cf2d7d016334eaf",
+          "version": "7.2.0"
         }
       },
       {
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
-          "revision": "7b07b214dacecb22ca4b680531c7e981d52483f9",
-          "version": "6.16.3"
+          "revision": "3fd8c77ded8a4bbee548e3bd6c987ffe8c1e3574",
+          "version": "6.17.0"
         }
       },
       {
@@ -213,8 +213,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "7e2c5f3cbbeea68e004915e3a8961e20bd11d824",
-          "version": "1.18.0"
+          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
+          "version": "1.19.0"
         }
       },
       {

--- a/Multisig/Cross-layer/Logger/CrashlyticsLogger.swift
+++ b/Multisig/Cross-layer/Logger/CrashlyticsLogger.swift
@@ -8,7 +8,6 @@ import Firebase
 /// Protocol for enabling logger tests
 public protocol CrashlyticsProtocol {
     func record(error: Error)
-    func setUserID(_ identifier: String)
     func log(format: String, arguments: CVaListPointer)
     func setCrashlyticsCollectionEnabled(_ enabled: Bool)
 }

--- a/Multisig/Features/Connect to Wallet/Logic/Models/WCAppRegistryEntry.swift
+++ b/Multisig/Features/Connect to Wallet/Logic/Models/WCAppRegistryEntry.swift
@@ -90,8 +90,8 @@ class WCAppRegistryEntry {
            link.host == nil || !(link.host == "apps.apple.com" || link.host == "itunes.apple.com" || link.host == "play.google.com"),
            var components = URLComponents(url: link, resolvingAgainstBaseURL: false)
         {
-            let encodedUri = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-            components.queryItems = [URLQueryItem(name: "uri", value: encodedUri)]
+            let encodedUri = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+            components.percentEncodedQuery = "uri=\(encodedUri)"
 
             if let url = components.url, url.lastPathComponent != "wc" {
                 components.path = url.appendingPathComponent("wc").path
@@ -102,8 +102,8 @@ class WCAppRegistryEntry {
             let link = linkMobileNative,
             var components = URLComponents(url: link, resolvingAgainstBaseURL: false)
         {
-            let encodedUri = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-            components.queryItems = [URLQueryItem(name: "uri", value: encodedUri)]
+            let encodedUri = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)!
+            components.percentEncodedQuery = "uri=\(encodedUri)"
 
             if components.scheme == nil && components.host == nil, let componentsUrl = components.url {
                 if componentsUrl.pathComponents.count == 1 {

--- a/Multisig/Features/Connect to Wallet/UI/WalletConnectionViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/WalletConnectionViewController.swift
@@ -51,7 +51,7 @@ class WalletConnectionViewController: UIViewController, WebConnectionObserver, U
             WebConnectionController.shared.attach(observer: self, to: connection)
 
             if let link = wallet.connectLink(from: connection.connectionURL) {
-                print("WC: Opening", link.absoluteString)
+                LogService.shared.debug("WC: Opening \(link.absoluteString)")
                 DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) { [weak self] in
                     UIApplication.shared.open(link, options: [:]) { success in
                         guard let self = self else { return }

--- a/MultisigTests/Logic/Models/WCAppRegistryEntryTests.swift
+++ b/MultisigTests/Logic/Models/WCAppRegistryEntryTests.swift
@@ -12,6 +12,7 @@ import WalletConnectSwift
 
 class WCAppRegistryEntryTests: XCTestCase {
     let wcUrl = WCURL(topic: "61f735f0-f883-48be-a366-7cf5fb53041a", version: "1", bridgeURL: URL(string: "https://bridge.example.com/")!, key: "453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
+    let encodedUri = "wc%3A61f735f0%2Df883%2D48be%2Da366%2D7cf5fb53041a%401%3Fbridge%3Dhttps%253A%252F%252Fbridge%2Eexample%2Ecom%252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2"
 
     func universalLinkEntry(baseUri universalUri: String) -> WCAppRegistryEntry {
         let result = WCAppRegistryEntry(id: "1", role: .wallet, chains: ["1"], versions: ["1"], name: "wallet", rank: 0, linkMobileUniversal: URL(string: universalUri))
@@ -24,20 +25,20 @@ class WCAppRegistryEntryTests: XCTestCase {
     }
 
     func testUniversalUri() {
-        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com"), expected: "https://example.com/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com/"), expected: "https://example.com/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com/app"), expected: "https://example.com/app/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: (universalLinkEntry(baseUri: "https://example.com/path/to/app/")), expected: "https://example.com/path/to/app/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com/wc"), expected: "https://example.com/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
+        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com"), expected: "https://example.com/wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com/"), expected: "https://example.com/wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com/app"), expected: "https://example.com/app/wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: (universalLinkEntry(baseUri: "https://example.com/path/to/app/")), expected: "https://example.com/path/to/app/wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: universalLinkEntry(baseUri: "https://example.com/wc"), expected: "https://example.com/wc?uri=\(encodedUri)")
     }
 
     func testDeeplinkUri() {
-        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example:"), expected: "example://wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://"), expected: "example://wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://wc"), expected: "example://wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://app/wc"), expected: "example://app/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://path/to/app"), expected: "example://path/to/app/wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
-        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example"), expected: "example://wc?uri=wc:61f735f0-f883-48be-a366-7cf5fb53041a@1?bridge%3Dhttps%25253A%25252F%25252Fbridge.example.com%25252F%26key%3D453064f36ee552ed3b0be18df5d192240fa2b3c083d2ce5aa3a5e6b812ba77f2")
+        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example:"), expected: "example://wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://"), expected: "example://wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://wc"), expected: "example://wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://app/wc"), expected: "example://app/wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example://path/to/app"), expected: "example://path/to/app/wc?uri=\(encodedUri)")
+        assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example"), expected: "example://wc?uri=\(encodedUri)")
         assertCorrectConnectUri(entry: deeplinkEntry(baseUri: "example/path"), expected: wcUrl.absoluteString)
     }
 


### PR DESCRIPTION
Handles #2052

Changes proposed in this pull request:
- The uri parameter encoding was not the one the other side expected. When changed, previously crashing wallets started to connect.