### PR TITLE
[iPad] Fix crash in add Safe

### DIFF
--- a/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
@@ -191,6 +191,10 @@ class WebConnectionDetailsViewController: UITableViewController, WebConnectionOb
             cell.backgroundColor = .clear
             cell.setText("Disconnect", style: .filledError) { [unowned self] in
                 let alertController = DisconnectionConfirmationController.create(connection: connection)
+                if let popoverPresentationController = alertController.popoverPresentationController {
+                                    popoverPresentationController.sourceView = tableView
+                                    popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+                                }
                 self.present(alertController, animated: true)
             }
             return cell

--- a/Multisig/Features/Connect to Web/UI/List/WebConnectionsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/List/WebConnectionsViewController.swift
@@ -157,8 +157,7 @@ class WebConnectionsViewController: UITableViewController, ExternalURLSource, We
                 guard let `self` = self else { return }
                 let alertController = DisconnectionConfirmationController.create(connection: connection)
                 if let popoverPresentationController = alertController.popoverPresentationController {
-                    popoverPresentationController.sourceView = tableView
-                    popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+                    popoverPresentationController.sourceView = tableView.cellForRow(at: indexPath)
                 }
                 self.present(alertController, animated: true)
             }]

--- a/Multisig/Features/Connect to Web/UI/List/WebConnectionsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/List/WebConnectionsViewController.swift
@@ -156,6 +156,10 @@ class WebConnectionsViewController: UITableViewController, ExternalURLSource, We
             UIContextualAction(style: .destructive, title: "Disconnect") {  [weak self] _, _, completion in
                 guard let `self` = self else { return }
                 let alertController = DisconnectionConfirmationController.create(connection: connection)
+                if let popoverPresentationController = alertController.popoverPresentationController {
+                    popoverPresentationController.sourceView = tableView
+                    popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+                }
                 self.present(alertController, animated: true)
             }]
         return UISwipeActionsConfiguration(actions: actions)

--- a/Multisig/UI/Assets/Transfer/TransactionViewController/TransactionViewController.swift
+++ b/Multisig/UI/Assets/Transfer/TransactionViewController/TransactionViewController.swift
@@ -123,6 +123,10 @@ class TransactionViewController: UIViewController {
     private func didTapAddressField() {
         let alertVC = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+        if let popoverPresentationController = alertVC.popoverPresentationController {
+            popoverPresentationController.sourceView = addressField
+        }
+
         alertVC.addAction(UIAlertAction(title: "Paste from Clipboard", style: .default, handler: { [weak self] _ in
             let text = Pasteboard.string
             self?.didEnterText(text)

--- a/Multisig/UI/Safe Management/Add Safe/EnterSafeAddressViewController/EnterSafeAddressViewController.swift
+++ b/Multisig/UI/Safe Management/Add Safe/EnterSafeAddressViewController/EnterSafeAddressViewController.swift
@@ -105,6 +105,9 @@ class EnterSafeAddressViewController: UIViewController {
     private func didTapAddressField() {
         let alertVC = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+        if let popoverPresentationController = alertVC.popoverPresentationController {
+            popoverPresentationController.sourceView = addressField
+        }
         alertVC.addAction(UIAlertAction(title: "Paste from Clipboard", style: .default, handler: { [weak self] _ in
             let text = Pasteboard.string
             self?.didEnterText(text)

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -97,9 +97,10 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
         uiModel.didEdit()
     }
 
-    @objc private func didTapAddOwnerButton(_ sender: Any) {
-        addOwner()
-    }
+    //TODO: Can this be deleted? Looks unused.
+//    @objc private func didTapAddOwnerButton(_ sender: Any) {
+//        addOwner()
+//    }
 
     // MARK: - Table View Data and Views
 
@@ -216,7 +217,7 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
             selectNetwork()
 
         case .owners:
-            selectOwnerRow(indexPath.row)
+            selectOwnerRow(tableView: tableView, indexPath: indexPath)
 
         case .threshold:
             selectConfirmationRow(indexPath.row)
@@ -262,14 +263,20 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
         show(selectNetworkVC, sender: self)
     }
 
-    func selectOwnerRow(_ rowIndex: Int) {
-        guard rowIndex == uiModel.owners.count else { return }
-        addOwner()
+    func selectOwnerRow(tableView: UITableView, indexPath: IndexPath) {
+        guard indexPath.row == uiModel.owners.count else { return }
+        addOwner(tableView: tableView, indexPath: indexPath)
     }
 
-    func addOwner() {
+    func addOwner(tableView: UITableView, indexPath: IndexPath) {
         let picker = SelectAddressViewController(chain: uiModel.chain, presenter: self) { [weak self] address in
             self?.uiModel.addOwnerAddress(address)
+        }
+
+        if let popoverPresentationController = picker.popoverPresentationController {
+            // TODO what view to use?
+            popoverPresentationController.sourceView = tableView
+            popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
         }
         present(picker, animated: true, completion: nil)
     }

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -97,11 +97,6 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
         uiModel.didEdit()
     }
 
-    //TODO: Can this be deleted? Looks unused.
-//    @objc private func didTapAddOwnerButton(_ sender: Any) {
-//        addOwner()
-//    }
-
     // MARK: - Table View Data and Views
 
     private func isValid(section: Int) -> Bool {
@@ -274,9 +269,7 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
         }
 
         if let popoverPresentationController = picker.popoverPresentationController {
-            // TODO what view to use?
-            popoverPresentationController.sourceView = tableView
-            popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+            popoverPresentationController.sourceView = tableView.cellForRow(at: indexPath)
         }
         present(picker, animated: true, completion: nil)
     }

--- a/Multisig/UI/Safe Management/SwitchSafesViewController/SwitchSafesViewController.swift
+++ b/Multisig/UI/Safe Management/SwitchSafesViewController/SwitchSafesViewController.swift
@@ -118,6 +118,12 @@ final class SwitchSafesViewController: UITableViewController {
                 title: nil,
                 message: nil,
                 preferredStyle: .actionSheet)
+
+            if let popoverPresentationController = alertController.popoverPresentationController {
+                popoverPresentationController.sourceView = tableView
+                popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+            }
+
             let addSafe = UIAlertAction(title: "Add existing safe", style: .default) { [weak self] _ in
                 self?.onAddSafe?()
             }

--- a/Multisig/UI/Safe Management/SwitchSafesViewController/SwitchSafesViewController.swift
+++ b/Multisig/UI/Safe Management/SwitchSafesViewController/SwitchSafesViewController.swift
@@ -169,7 +169,7 @@ final class SwitchSafesViewController: UITableViewController {
         var actions = [UIContextualAction]()
 
         let deleteAction = UIContextualAction(style: .destructive, title: "Remove") { [unowned self] _, _, completion in
-            self.remove(safe: safe)
+            self.remove(safe: safe, tableView: tableView, indexPath: indexPath)
             completion(true)
         }
         actions.append(deleteAction)
@@ -177,7 +177,7 @@ final class SwitchSafesViewController: UITableViewController {
         return UISwipeActionsConfiguration(actions: actions)
     }
 
-    private func remove(safe: Safe) {
+    private func remove(safe: Safe, tableView: UITableView, indexPath: IndexPath) {
         let title = safe.safeStatus == .deployed ?
         "Removing a Safe only removes it from this app. It does not delete the Safe from the blockchain. Funds will not get lost." :
         "Are you sure you want to remove this Safe? The transaction fees will not be returned."
@@ -185,6 +185,12 @@ final class SwitchSafesViewController: UITableViewController {
             title: nil,
             message: title,
             preferredStyle: .actionSheet)
+
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            popoverPresentationController.sourceView = tableView
+            popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+        }
+
         let remove = UIAlertAction(title: "Remove", style: .destructive) { _ in
             Safe.remove(safe: safe)
         }

--- a/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
+++ b/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
@@ -107,8 +107,7 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
         alertController.addAction(cancelButton)
 
         if let popoverPresentationController = alertController.popoverPresentationController {
-            //TODO: What view should be used? tableView is wrong
-            popoverPresentationController.sourceView = tableView
+            popoverPresentationController.barButtonItem = menuButton
         }
 
         self.present(alertController, animated: true)

--- a/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
+++ b/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
@@ -67,11 +67,6 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
             title: nil,
             message: nil,
             preferredStyle: .actionSheet)
-
-        if let popoverPresentationController = alertController.popoverPresentationController {
-            popoverPresentationController.sourceView = tableView
-        }
-
         let addEnityButton = UIAlertAction(title: "Add new entry", style: .default) { _ in
             self.didTapAddButton()
         }
@@ -110,6 +105,11 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
 
         let cancelButton = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         alertController.addAction(cancelButton)
+
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            //TODO: What view should be used? tableView is wrong
+            popoverPresentationController.sourceView = tableView
+        }
 
         self.present(alertController, animated: true)
     }
@@ -188,7 +188,7 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
         actions.append(editAction)
 
         let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [unowned self] _, _, completion in
-            self.remove(entry)
+            self.remove(entry, tableView: tableView, indexPath: indexPath)
             completion(true)
         }
         actions.append(deleteAction)
@@ -232,11 +232,15 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
         show(ribbonVC, sender: nil)
     }
 
-    private func remove(_ entry: AddressBookEntry) {
+    private func remove(_ entry: AddressBookEntry, tableView: UITableView, indexPath: IndexPath) {
         let alertController = UIAlertController(
             title: nil,
             message: "Removing the entry key only removes it from this app.",
             preferredStyle: .actionSheet)
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            popoverPresentationController.sourceView = tableView
+            popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+        }
         let remove = UIAlertAction(title: "Remove", style: .destructive) { _ in
             AddressBookEntry.remove(entry: entry)
             App.shared.snackbar.show(message: "Address book entry removed")

--- a/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
+++ b/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
@@ -67,6 +67,11 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
             title: nil,
             message: nil,
             preferredStyle: .actionSheet)
+
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            popoverPresentationController.sourceView = tableView
+        }
+
         let addEnityButton = UIAlertAction(title: "Add new entry", style: .default) { _ in
             self.didTapAddButton()
         }

--- a/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
+++ b/Multisig/UI/Settings/AddressBook/AddressBookListTableViewController.swift
@@ -67,11 +67,16 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
             title: nil,
             message: nil,
             preferredStyle: .actionSheet)
-        let addEnityButton = UIAlertAction(title: "Add new entry", style: .default) { _ in
+
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            popoverPresentationController.barButtonItem = menuButton
+        }
+
+        let addEntityButton = UIAlertAction(title: "Add new entry", style: .default) { _ in
             self.didTapAddButton()
         }
 
-        alertController.addAction(addEnityButton)
+        alertController.addAction(addEntityButton)
 
         let importEntryButton = UIAlertAction(title: "Import entries", style: .default) { [unowned self] _ in
             let pricker = UIDocumentPickerViewController(documentTypes: [String(kUTTypeCommaSeparatedText)], in: .import)
@@ -105,10 +110,6 @@ class AddressBookListTableViewController: LoadableViewController, UITableViewDel
 
         let cancelButton = UIAlertAction(title: "Cancel", style: .cancel, handler: nil)
         alertController.addAction(cancelButton)
-
-        if let popoverPresentationController = alertController.popoverPresentationController {
-            popoverPresentationController.barButtonItem = menuButton
-        }
 
         self.present(alertController, animated: true)
     }

--- a/Multisig/UI/Settings/AddressBook/CreateAddressBookEntryViewController.swift
+++ b/Multisig/UI/Settings/AddressBook/CreateAddressBookEntryViewController.swift
@@ -58,6 +58,9 @@ class CreateAddressBookEntryViewController: UIViewController {
     private func didTapAddressField() {
         let alertVC = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+        if let popoverPresentationController = alertVC.popoverPresentationController {
+            popoverPresentationController.sourceView = addressField
+        }
         alertVC.addAction(UIAlertAction(title: "Paste from Clipboard", style: .default, handler: { [weak self] _ in
             let text = Pasteboard.string
             self?.didEnterText(text)

--- a/Multisig/UI/Settings/OwnerKeyManagement/LedgerOwnerKey/SelectLedgerDeviceViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/LedgerOwnerKey/SelectLedgerDeviceViewController.swift
@@ -133,12 +133,6 @@ extension SelectLedgerDeviceViewController: BluetoothControllerDelegate {
             let alertVC = UIAlertController(title: nil,
                                             message: "Please enable Bluetooth in App Settings",
                                             preferredStyle: .alert)
-
-            if let popoverPresentationController = alertVC.popoverPresentationController {
-                //TODO untested
-                popoverPresentationController.sourceView = tableView
-            }
-
             let cancel = UIAlertAction(title: "Cancel", style: .cancel)
             let settings = UIAlertAction(title: "Settings", style: .default) { _ in
                 let url = URL(string: UIApplication.openSettingsURLString)!

--- a/Multisig/UI/Settings/OwnerKeyManagement/LedgerOwnerKey/SelectLedgerDeviceViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/LedgerOwnerKey/SelectLedgerDeviceViewController.swift
@@ -134,6 +134,11 @@ extension SelectLedgerDeviceViewController: BluetoothControllerDelegate {
                                             message: "Please enable Bluetooth in App Settings",
                                             preferredStyle: .alert)
 
+            if let popoverPresentationController = alertVC.popoverPresentationController {
+                //TODO untested
+                popoverPresentationController.sourceView = tableView
+            }
+
             let cancel = UIAlertAction(title: "Cancel", style: .cancel)
             let settings = UIAlertAction(title: "Settings", style: .default) { _ in
                 let url = URL(string: UIApplication.openSettingsURLString)!

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
@@ -188,7 +188,7 @@ class OwnerKeysListViewController: LoadableViewController, UITableViewDelegate, 
         }
 
         let deleteAction = UIContextualAction(style: .destructive, title: "Delete") { [unowned self] _, _, completion in
-            self.remove(key: keyInfo)
+            self.remove(key: keyInfo, tableView: tableView, indexPath: indexPath)
             completion(true)
         }
         actions.append(deleteAction)
@@ -221,11 +221,17 @@ class OwnerKeysListViewController: LoadableViewController, UITableViewDelegate, 
         present(vc, animated: true)
     }
 
-    private func remove(key: KeyInfo) {
+    private func remove(key: KeyInfo, tableView: UITableView, indexPath: IndexPath) {
         let alertController = UIAlertController(
             title: nil,
             message: "Removing the owner key only removes it from this app. It doesn’t delete any Safes from this app or from blockchain. Transactions for Safes controlled by this key will no longer be available for signing in this app.",
             preferredStyle: .actionSheet)
+
+        if let popoverPresentationController = alertController.popoverPresentationController {
+            popoverPresentationController.sourceView = tableView
+            popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+        }
+
         let remove = UIAlertAction(title: "Remove", style: .destructive) { _ in
             OwnerKeyController.remove(keyInfo: key)
         }

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
@@ -171,6 +171,11 @@ class OwnerKeysListViewController: LoadableViewController, UITableViewDelegate, 
 
                 if isConnected {
                     let alertController = DisconnectionConfirmationController.create(key: keyInfo)
+                    if let popoverPresentationController = alertController.popoverPresentationController {
+                        popoverPresentationController.sourceView = tableView
+                        popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+                    }
+
                     self.present(alertController, animated: true)
                 } else {
                     // try to reconnect

--- a/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
@@ -241,6 +241,12 @@ class SafeSettingsViewController: LoadableViewController, UITableViewDelegate, U
                     title: nil,
                     message: "Removing a Safe only removes it from this app. It does not delete the Safe from the blockchain. Funds will not get lost.",
                     preferredStyle: .actionSheet)
+
+                if let popoverPresentationController = alertController.popoverPresentationController {
+                    popoverPresentationController.sourceView = tableView
+                    popoverPresentationController.sourceRect = tableView.rectForRow(at: indexPath)
+                }
+
                 let remove = UIAlertAction(title: "Remove", style: .destructive) { _ in
                     Safe.remove(safe: self.safe)
                 }


### PR DESCRIPTION
Handles #

Changes proposed in this pull request:
- Fix crash in iPad build when adding a safe
- This approach can probably used in all places, that use an UIAlertCOntroller
- It doesn't seem to have any negative effect on iphones

Remaining problems:
- No notifications (on MacOS)
- No WalletConnect handover to other ios-wallets (on macOS)

Source: https://stackoverflow.com/a/36947305/199972

![image](https://user-images.githubusercontent.com/246473/158994382-80151f06-b705-4675-97c0-410407b382f7.png)
![image](https://user-images.githubusercontent.com/246473/158997059-fd39344c-d067-46d7-8e91-ed9e225a72ef.png)
![image](https://user-images.githubusercontent.com/246473/159006574-6abe3a89-07dd-4e71-80a0-dc2371857ec6.png)
![image](https://user-images.githubusercontent.com/246473/159008983-a5e91f33-afae-4d87-9471-04df253699c1.png)
