### PR TITLE
GH-2093 - Disable Key change in Connection details

### DIFF
--- a/Multisig/Features/Connect to Web/Logic/Model/WebConnection.swift
+++ b/Multisig/Features/Connect to Web/Logic/Model/WebConnection.swift
@@ -52,6 +52,19 @@ class WebConnection {
         self.remotePeer = remotePeer
         self.lastError = lastError
     }
+    var connectedAsDapp: Bool {
+        if status == .opened, let localPeer = localPeer, let remotePeer = remotePeer {
+            return localPeer.role == WebConnectionPeerRole.dapp && remotePeer.role == WebConnectionPeerRole.wallet
+        }
+        return false
+    }
+
+    var connectedAsWallet: Bool {
+        if status == .opened, let localPeer = localPeer, let remotePeer = remotePeer {
+            return localPeer.role == WebConnectionPeerRole.wallet && remotePeer.role == WebConnectionPeerRole.dapp
+        }
+        return false
+    }
 }
 
 enum WebConnectionStatus: Int16 {

--- a/Multisig/Logic/Models/KeyInfo.swift
+++ b/Multisig/Logic/Models/KeyInfo.swift
@@ -40,7 +40,7 @@ extension KeyInfo {
         name ?? "Key \(address.ellipsized())"
     }
 
-    var connected: Bool {
+    var connectedAsDapp: Bool {
         guard keyType == .walletConnect, let connections = connections else { return false }
         let walletConnections = connections
                 .compactMap { $0 as? CDWCConnection }

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -250,7 +250,7 @@ class OwnerKeyDetailsViewController: UITableViewController {
         case Section.Connected.connected:
             return tableView.switchCell(for: indexPath,
                                            with: "Connected",
-                                           isOn: keyInfo.connected)
+                                           isOn: keyInfo.connectedAsDapp)
         case Section.PushNotificationConfiguration.enabled:
             return tableView.switchCell(for: indexPath, with: "Receive Push Notifications", isOn: keyInfo.delegateAddress != nil)
         case Section.DelegateKey.address:
@@ -271,7 +271,7 @@ class OwnerKeyDetailsViewController: UITableViewController {
     private func keyTypeCell(type: KeyType, indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueCell(KeyTypeTableViewCell.self, for: indexPath)
         cell.set(name: type.name, iconName: type.imageName)
-        if !(type == .walletConnect && keyInfo.connected) {
+        if !(type == .walletConnect && keyInfo.connectedAsDapp) {
             cell.setDisclosureImage(nil)
         } else {
             cell.setDisclosureImage(UIImage(named: "arrow"))
@@ -290,7 +290,7 @@ class OwnerKeyDetailsViewController: UITableViewController {
             let vc = EditOwnerKeyViewController(keyInfo: keyInfo)
             show(vc, sender: self)
         case Section.Connected.connected:
-            if keyInfo.connected {
+            if keyInfo.connectedAsDapp {
                 let alertController = DisconnectionConfirmationController.create(key: keyInfo)
                 present(alertController, animated: true)
             } else {
@@ -317,7 +317,7 @@ class OwnerKeyDetailsViewController: UITableViewController {
             }
             return
         case Section.OwnerKeyType.type:
-            if keyInfo.keyType == .walletConnect && keyInfo.connected {
+            if keyInfo.keyType == .walletConnect && keyInfo.connectedAsDapp {
                 let detailsVC = WebConnectionDetailsViewController()
                 guard let webConnection = WebConnectionController.shared.walletConnection(keyInfo: keyInfo).first else {
                     return

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
@@ -164,7 +164,7 @@ class OwnerKeysListViewController: LoadableViewController, UITableViewDelegate, 
         actions.append(editAction)
 
         if keyInfo.keyType == .walletConnect {
-            let isConnected = keyInfo.connected
+            let isConnected = keyInfo.connectedAsDapp
 
             let wcAction = UIContextualAction(style: .normal, title: isConnected ? "Disconnect" : "Connect") {
                 [unowned self] _, _, completion in

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/SigningKeyTableViewCell.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/SigningKeyTableViewCell.swift
@@ -79,7 +79,7 @@ enum KeyConnectionStatus {
         case .deviceGenerated, .deviceImported, .ledgerNanoX:
             self = .none
         case .walletConnect:
-            if keyInfo.connected {
+            if keyInfo.connectedAsDapp {
                 if let _  = keyInfo.connections!.first(where: { connection in
                     "\((connection as! CDWCConnection).chainId)" == chainID
                 }) {


### PR DESCRIPTION
Handles #2093

Changes proposed in this pull request:
- In connect to web key change shoud still be possible
- In WalletConnectconncetion details it shouldn't

Connect to Web details | WalletConnect Details
----------------------- | -----------------------
![image](https://user-images.githubusercontent.com/246473/159270331-72680856-8e01-4b8c-a478-61d95e47ee9a.png) | ![image](https://user-images.githubusercontent.com/246473/159270414-a5816a19-cf29-476f-81b4-d549caf83577.png)



