### PR TITLE
gh-2055 Wallet signature request

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -683,6 +683,7 @@
 		6A91EFDA27DA2C8D009E63E9 /* wc_registry_wallets.json in Resources */ = {isa = PBXBuildFile; fileRef = 6A91EFD927DA2C8D009E63E9 /* wc_registry_wallets.json */; };
 		6A91EFDC27DA2CF9009E63E9 /* WCAppRegistryRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A91EFDB27DA2CF9009E63E9 /* WCAppRegistryRepositoryTests.swift */; };
 		6AA2724A27DF566B00934B37 /* PendingWalletActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA2724827DF566B00934B37 /* PendingWalletActionViewController.swift */; };
+		6AC2D47727EC661D00D422CA /* SignatureRequestToWalletViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC2D47627EC661D00D422CA /* SignatureRequestToWalletViewController.swift */; };
 		6ADEB01B2795AB410062ADFE /* InfoLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADEB0192795AB410062ADFE /* InfoLabel.swift */; };
 		6ADEB01C2795AB410062ADFE /* InfoLabel.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6ADEB01A2795AB410062ADFE /* InfoLabel.xib */; };
 		6ADEB02727B559370062ADFE /* WebConnectionOwnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ADEB02527B559370062ADFE /* WebConnectionOwnerView.swift */; };
@@ -1458,6 +1459,7 @@
 		6A91EFD927DA2C8D009E63E9 /* wc_registry_wallets.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = wc_registry_wallets.json; sourceTree = "<group>"; };
 		6A91EFDB27DA2CF9009E63E9 /* WCAppRegistryRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCAppRegistryRepositoryTests.swift; sourceTree = "<group>"; };
 		6AA2724827DF566B00934B37 /* PendingWalletActionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingWalletActionViewController.swift; sourceTree = "<group>"; };
+		6AC2D47627EC661D00D422CA /* SignatureRequestToWalletViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureRequestToWalletViewController.swift; sourceTree = "<group>"; };
 		6ADEB0192795AB410062ADFE /* InfoLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoLabel.swift; sourceTree = "<group>"; };
 		6ADEB01A2795AB410062ADFE /* InfoLabel.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InfoLabel.xib; sourceTree = "<group>"; };
 		6ADEB02527B559370062ADFE /* WebConnectionOwnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebConnectionOwnerView.swift; sourceTree = "<group>"; };
@@ -3439,6 +3441,7 @@
 				0A0C75B127E8AB620083AE01 /* SendTransactionToWalletViewController.swift */,
 				6AA2724827DF566B00934B37 /* PendingWalletActionViewController.swift */,
 				0AF78A3127E0E07B001BAFE0 /* PendingWalletActionViewController.xib */,
+				6AC2D47627EC661D00D422CA /* SignatureRequestToWalletViewController.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -4279,6 +4282,7 @@
 				0AFA72A024BF368900A370EE /* SlicedText+Address.swift in Sources */,
 				0ADD199E265E518600EB0F2B /* UIView+Pin.swift in Sources */,
 				04B4B6E525B9A08D00CFE24B /* CardTableViewCell.swift in Sources */,
+				6AC2D47727EC661D00D422CA /* SignatureRequestToWalletViewController.swift in Sources */,
 				5596C03E25507F3C00EF23A5 /* CollectibleTableViewCell.swift in Sources */,
 				0A3FDAEC26AEB5BF006A7DC3 /* KeyInfo+Shared.swift in Sources */,
 				04CE3F9924B6120F00826AEE /* CollectibleMetaData.swift in Sources */,

--- a/Multisig/Features/Connect to Wallet/UI/SendTransactionToWalletViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/SendTransactionToWalletViewController.swift
@@ -13,12 +13,9 @@ import WalletConnectSwift
 class SendTransactionToWalletViewController: PendingWalletActionViewController, WebConnectionObserver {
 
     var transaction: Client.Transaction!
-    var keyInfo: KeyInfo!
-    var chain: Chain!
     var timer: Timer?
     var requestTimeout: TimeInterval = 120
 
-    var connection: WebConnection?
     var onSuccess: ((Data) -> ())?
 
     convenience init(transaction: Client.Transaction, keyInfo: KeyInfo, chain: Chain) {
@@ -56,35 +53,6 @@ class SendTransactionToWalletViewController: PendingWalletActionViewController, 
         }
     }
 
-    func connect(completion: @escaping (WebConnection?) -> ()) {
-        let walletConnectionVC = StartWalletConnectionViewController(wallet: wallet, chain: chain)
-
-        walletConnectionVC.onSuccess = { [weak walletConnectionVC, weak self] connection in
-            walletConnectionVC?.dismiss(animated: true) {
-                guard let self = self else { return }
-                guard connection.accounts.contains(self.keyInfo.address) else {
-                    App.shared.snackbar.show(error: GSError.WCConnectedKeyMissingAddress())
-                    return
-                }
-
-                if OwnerKeyController.updateKey(connection: connection, wallet: self.wallet) {
-                    App.shared.snackbar.show(message: "Key connected successfully")
-                }
-
-                completion(connection)
-            }
-        }
-
-        walletConnectionVC.onCancel = { [weak walletConnectionVC] in
-            walletConnectionVC?.dismiss(animated: true, completion: {
-                completion(nil)
-            })
-        }
-
-        let vc = ViewControllerFactory.pageSheet(viewController: walletConnectionVC, halfScreen: true)
-        present(vc, animated: true)
-    }
-
     func send() {
         guard checkNetwork() else {
             App.shared.snackbar.show(message: "Please change wallet network to \(chain.name!)")
@@ -111,31 +79,7 @@ class SendTransactionToWalletViewController: PendingWalletActionViewController, 
                 self.onSuccess?(data)
             }
         }
-
         openWallet(connection: connection)
-    }
-
-    func openWallet(connection: WebConnection) {
-        if let link = wallet.navigateLink(from: connection.connectionURL) {
-            LogService.shared.debug("WC: Opening \(link.absoluteString)")
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
-                UIApplication.shared.open(link, options: [:]) { success in
-                    if !success {
-                        App.shared.snackbar.show(message: "Failed to open the wallet automatically. Please open it manually or try again.")
-                    }
-                }
-            }
-        } else {
-            App.shared.snackbar.show(message: "Please open your wallet to complete this operation.")
-        }
-    }
-
-    func checkNetwork() -> Bool {
-        guard let connection = connection,
-              let chainId = connection.chainId,
-              String(chainId) == self.chain.id else { return false }
-
-        return true
     }
 
     override func didTapCancel(_ sender: Any) {

--- a/Multisig/Features/Connect to Wallet/UI/SignatureRequestToWalletViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/SignatureRequestToWalletViewController.swift
@@ -1,0 +1,148 @@
+//
+//  SignatureRequestToWalletViewController.swift
+//  Multisig
+//
+//  Created by Vitaly on 24.03.22.
+//  Copyright © 2022 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import WalletConnectSwift
+
+class SignatureRequestToWalletViewController: PendingWalletActionViewController, WebConnectionObserver {
+
+    private var transaction: Transaction?
+    private var clientTransaction: Client.Transaction?
+    private var message: String?
+
+    var timer: Timer?
+    var requestTimeout: TimeInterval = 120
+
+    var onSuccess: ((String) -> ())?
+
+    convenience init(_ transaction: Client.Transaction, keyInfo: KeyInfo, chain: Chain) {
+        self.init(namedClass: PendingWalletActionViewController.self)
+        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.keyInfo = keyInfo
+        self.clientTransaction = transaction
+        self.chain = chain
+    }
+    
+    convenience init(_ transaction: Transaction, keyInfo: KeyInfo, chain: Chain) {
+        self.init(namedClass: PendingWalletActionViewController.self)
+        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.keyInfo = keyInfo
+        self.transaction = transaction
+        self.chain = chain
+    }
+    
+    convenience init(_ message: String, keyInfo: KeyInfo, chain: Chain) {
+        self.init(namedClass: PendingWalletActionViewController.self)
+        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.keyInfo = keyInfo
+        self.message = message
+        self.chain = chain
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if transaction != nil {
+            titleLabel.text = "Confirm Transaction with your owner key from \(wallet.name)"
+        } else {
+            titleLabel.text = "Approve request with your owner key from \(wallet.name)"
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        requestSignatureWhenConnected()
+    }
+
+    func requestSignatureWhenConnected() {
+        let connections = WebConnectionController.shared.walletConnection(keyInfo: keyInfo)
+        if let connection = connections.first {
+            self.connection = connection
+                send()
+        } else {
+            connect { [ unowned self] connection in
+                self.connection = connection
+                if connection != nil {
+                    self.requestSignature()
+                } else {
+                    onCancel()
+                }
+            }
+        }
+    }
+
+    func requestSignature() {
+        guard checkNetwork() else {
+            App.shared.snackbar.show(message: "Please change wallet network to \(chain.name!)")
+            return
+        }
+        guard let connection = connection else { return }
+
+        WebConnectionController.shared.detach(observer: self)
+        WebConnectionController.shared.attach(observer: self, to: connection)
+
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: requestTimeout, repeats: false, block: { [weak self] _ in
+            guard let self = self else { return }
+            self.onCancel()
+        })
+
+        if let transaction = transaction {
+            WebConnectionController.shared.wcSign(connection: connection, transaction: transaction) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .failure(let error):
+                    App.shared.snackbar.show(message: error.localizedDescription)
+                    self.onCancel()
+                case .success(let signature):
+                    self?.handleSignResponse(signature: signature, completion: onSuccess)
+                }
+            }
+            openWallet(connection: connection)
+        } else if let message = message {
+            WebConnectionController.shared.wcSign(connection: connection, message: message) { [weak self] result in
+                guard let self = self else { return }
+                switch result {
+                case .failure(let error):
+                    App.shared.snackbar.show(message: error.localizedDescription)
+                    self.onCancel()
+                case .success(let signature):
+                    self?.handleSignResponse(signature: signature, completion: onSuccess)
+                }
+            }
+        }
+    }
+    
+    private func handleSignResponse(signature: String?, completion: ((String) -> Void)?) {
+        DispatchQueue.main.async { [weak self] in
+            guard let signature = signature else {
+                App.shared.snackbar.show(error: GSError.CouldNotSignWithWalletConnect())
+                return
+            }
+            
+            self?.dismiss(animated: true, completion: nil)
+            completion?(signature)
+        }
+    }
+
+    override func didTapCancel(_ sender: Any) {
+        onCancel()
+    }
+    
+    func didUpdate(connection: WebConnection) {
+        if connection.status == .final {
+            onCancel()
+        }
+    }
+
+    deinit {
+        WebConnectionController.shared.detach(observer: self)
+    }
+}
+

--- a/Multisig/Features/Connect to Wallet/UI/SignatureRequestToWalletViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/SignatureRequestToWalletViewController.swift
@@ -122,6 +122,7 @@ class SignatureRequestToWalletViewController: PendingWalletActionViewController,
                     self.handleSignResponse(signature: signature, completion: self.onSuccess)
                 }
             }
+            openWallet(connection: connection)
         }
     }
     
@@ -131,8 +132,6 @@ class SignatureRequestToWalletViewController: PendingWalletActionViewController,
                 App.shared.snackbar.show(error: GSError.CouldNotSignWithWalletConnect())
                 return
             }
-            
-            self?.dismiss(animated: true, completion: nil)
             completion?(signature)
         }
     }

--- a/Multisig/Features/Connect to Wallet/UI/StartWalletConnectionViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/StartWalletConnectionViewController.swift
@@ -12,9 +12,6 @@ import UIKit
 class StartWalletConnectionViewController: PendingWalletActionViewController, WebConnectionObserver {
     var onSuccess: (_ connection: WebConnection) -> Void = { _ in }
 
-    private var chain: Chain!
-    private var connection: WebConnection!
-
     convenience init(wallet: WCAppRegistryEntry, chain: Chain) {
         self.init(namedClass: PendingWalletActionViewController.self)
         self.wallet = wallet

--- a/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
@@ -394,26 +394,26 @@ class SendTransactionRequestViewController: WebConnectionContainerViewController
                     guard success else {
                         return
                     }
-
-                    let wcVC = WCPendingConfirmationViewController(
-                        clientTx,
+                    
+                    let vc = SendTransactionToWalletViewController(
+                        transaction: clientTx,
                         keyInfo: self.keyInfo,
-                        title: "Sign Transaction"
+                        chain: self.chain ?? Chain.mainnetChain()
                     )
-
-                    wcVC.send { [weak self] txHash in
-                        guard let self = self else { return }
-                        assert(Thread.isMainThread)
-
-                        if let hexHash = txHash {
-                            self.didSubmitTransaction(txHash: Eth.Hash(Data(hex: hexHash)))
-                            self.didSubmitSuccess()
-                        } else {
+                    vc.onCancel = { [weak vc] in
+                        vc?.dismiss(animated: true) {
                             self.didSubmitFailed(nil)
                         }
                     }
-
-                    self.present(wcVC, animated: true)
+                    vc.onSuccess = { [weak self, weak vc] txHashData in
+                        guard let self = self else { return }
+                        assert(Thread.isMainThread)
+                        vc?.dismiss(animated: true) {
+                            self.didSubmitTransaction(txHash: Eth.Hash(txHashData))
+                            self.didSubmitSuccess()
+                        }
+                    }
+                    self.present(vc, animated: true)
                 }
             }
 

--- a/Multisig/Features/Connect to Web/UI/Signature Request/SignatureRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Signature Request/SignatureRequestViewController.swift
@@ -216,20 +216,16 @@ class SignatureRequestViewController: WebConnectionContainerViewController, WebC
 
                     let hexMessage = self.request.message.toHexStringWithPrefix()
 
-                    let wcVC = WCPendingConfirmationViewController(
-                        hexMessage,
-                        keyInfo: keyInfo,
-                        title: "Sign Message"
-                    )
-
-                    wcVC.sign { [weak self] hexSignature in
+                    let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: self.chain ?? Chain.mainnetChain())
+                    vc.onSuccess = { [weak self, weak vc] signature in
                         guard let self = self else { return }
                         assert(Thread.isMainThread)
-                        let signature = Data(hex: hexSignature)
-                        self.confirm(signature: signature)
+                        vc?.dismiss(animated: true) {
+                            let signature = Data(hex: signature)
+                            self.confirm(signature: signature)
+                        }
                     }
-
-                    self.present(wcVC, animated: true)
+                    self.present(vc, animated: true)
                 }
             }
 

--- a/Multisig/Features/Connect to Web/UI/Signature Request/SignatureRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Signature Request/SignatureRequestViewController.swift
@@ -203,31 +203,18 @@ class SignatureRequestViewController: WebConnectionContainerViewController, WebC
             }
 
         case .walletConnect:
-            wcConnector = WCWalletConnectionController()
-            wcConnector.connect(keyInfo: keyInfo, from: self) { [weak self] success in
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) { [weak self] in
-                    guard let self = self else { return }
+            let hexMessage = self.request.message.toHexStringWithPrefix()
 
-                    defer { self.wcConnector = nil }
-
-                    guard success else {
-                        return
-                    }
-
-                    let hexMessage = self.request.message.toHexStringWithPrefix()
-
-                    let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: self.chain ?? Chain.mainnetChain())
-                    vc.onSuccess = { [weak self, weak vc] signature in
-                        guard let self = self else { return }
-                        assert(Thread.isMainThread)
-                        vc?.dismiss(animated: true) {
-                            let signature = Data(hex: signature)
-                            self.confirm(signature: signature)
-                        }
-                    }
-                    self.present(vc, animated: true)
+            let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: self.chain ?? Chain.mainnetChain())
+            vc.onSuccess = { [weak self, weak vc] signature in
+                guard let self = self else { return }
+                assert(Thread.isMainThread)
+                vc?.dismiss(animated: true) {
+                    let signature = Data(hex: signature)
+                    self.confirm(signature: signature)
                 }
             }
+            self.present(vc, animated: true)
 
         case .ledgerNanoX:
             let hexToSign = request.message.toHexStringWithPrefix()

--- a/Multisig/UI/Assets/Transfer/ReviewSendFundsTrasnactionViewController/ReviewSendFundsTransactionViewController.swift
+++ b/Multisig/UI/Assets/Transfer/ReviewSendFundsTrasnactionViewController/ReviewSendFundsTransactionViewController.swift
@@ -208,11 +208,15 @@ class ReviewSendFundsTransactionViewController: UIViewController {
 
         case .walletConnect:
             let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
-            vc.onSuccess = { [weak self] signature in
-                self?.confirm(transaction: transaction, keyInfo: keyInfo, signature: signature)
+            vc.onSuccess = { [weak self, weak vc] signature in
+                vc?.dismiss(animated: true) {
+                    self?.confirm(transaction: transaction, keyInfo: keyInfo, signature: signature)
+                }
             }
-            vc.onCancel = { [weak self] in
-                self?.endConfirm()
+            vc.onCancel = { [weak self, weak vc] in
+                vc?.dismiss(animated: true) {
+                    self?.endConfirm()
+                }
             }
             presentModal(vc)
 

--- a/Multisig/UI/Assets/Transfer/ReviewSendFundsTrasnactionViewController/ReviewSendFundsTransactionViewController.swift
+++ b/Multisig/UI/Assets/Transfer/ReviewSendFundsTrasnactionViewController/ReviewSendFundsTransactionViewController.swift
@@ -207,17 +207,14 @@ class ReviewSendFundsTransactionViewController: UIViewController {
             }
 
         case .walletConnect:
-            let vc = WCPendingConfirmationViewController(transaction, keyInfo: keyInfo, title: "Confirm Transaction")
-
-            vc.onClose = { [weak self] in
-                self?.endConfirm()
-            }
-
-            presentModal(vc)
-
-            vc.sign() { [weak self] signature in
+            let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
+            vc.onSuccess = { [weak self] signature in
                 self?.confirm(transaction: transaction, keyInfo: keyInfo, signature: signature)
             }
+            vc.onCancel = { [weak self] in
+                self?.endConfirm()
+            }
+            presentModal(vc)
 
         case .ledgerNanoX:
             let request = SignRequest(title: "Confirm Transaction",

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -752,26 +752,26 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
                     guard success else {
                         return
                     }
-
-                    let wcVC = WCPendingConfirmationViewController(
-                        clientTx,
+                    
+                    let vc = SendTransactionToWalletViewController(
+                        transaction: clientTx,
                         keyInfo: keyInfo,
-                        title: "Sign Transaction"
+                        chain: self.chain ?? Chain.mainnetChain()
                     )
-
-                    wcVC.send { [weak self] txHash in
-                        guard let self = self else { return }
-                        assert(Thread.isMainThread)
-
-                        if let hexHash = txHash {
-                            self.uiModel.didSubmitTransaction(txHash: Eth.Hash(Data(hex: hexHash)))
-                            self.uiModel.didSubmitSuccess()
-                        } else {
+                    vc.onCancel = { [weak vc] in
+                        vc?.dismiss(animated: true) {
                             self.uiModel.didSubmitFailed(nil)
                         }
                     }
-
-                    self.present(wcVC, animated: true)
+                    vc.onSuccess = { [weak self, weak vc] txHashData in
+                        guard let self = self else { return }
+                        assert(Thread.isMainThread)
+                        vc?.dismiss(animated: true) {
+                            self.uiModel.didSubmitTransaction(txHash: Eth.Hash(txHashData))
+                            self.uiModel.didSubmitSuccess()
+                        }
+                    }
+                    self.present(vc, animated: true)
                 }
             }
 

--- a/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
@@ -170,13 +170,17 @@ class DelegateKeyController {
             let chain = try? Safe.getSelected()?.chain ?? Chain.mainnetChain()
             let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: chain!)
             var isSuccess: Bool = false
-            vc.onSuccess = { signature in
-                isSuccess = true
-                completion(.success(Data(hex: signature)))
+            vc.onSuccess = { [weak vc] signature in
+                vc?.dismiss(animated: true) {
+                    isSuccess = true
+                    completion(.success(Data(hex: signature)))
+                }
             }
-            vc.onCancel = {
-                if !isSuccess {
-                    completion(.failure(GSError.AddDelegateKeyCancelled()))
+            vc.onCancel = { [weak vc]
+                vc?.dismiss(animated: true) {
+                    if !isSuccess {
+                        completion(.failure(GSError.AddDelegateKeyCancelled()))
+                    }
                 }
             }
             presenter?.present(vc, animated: true)

--- a/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
@@ -176,7 +176,7 @@ class DelegateKeyController {
                     completion(.success(Data(hex: signature)))
                 }
             }
-            vc.onCancel = { [weak vc]
+            vc.onCancel = { [weak vc] in
                 vc?.dismiss(animated: true) {
                     if !isSuccess {
                         completion(.failure(GSError.AddDelegateKeyCancelled()))

--- a/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
@@ -167,22 +167,18 @@ class DelegateKeyController {
             }
 
         case .walletConnect:
-            let vc = WCPendingConfirmationViewController(hexMessage, keyInfo: keyInfo, title: title)
-
-            presenter?.present(vc, animated: true)
-
+            let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: safe.chain!)
             var isSuccess: Bool = false
-
-            vc.onClose = {
+            vc.onSuccess = { [weak self] signature in
+                isSuccess = true
+                completion(.success(Data(hex: signature)))
+            }
+            vc.onCancel = { [weak self] in
                 if !isSuccess {
                     completion(.failure(GSError.AddDelegateKeyCancelled()))
                 }
             }
-
-            vc.sign() { signature in
-                isSuccess = true
-                completion(.success(Data(hex: signature)))
-            }
+            presenter?.present(vc, animated: true)
 
         default:
             completion(.failure(GSError.UnrecognizedKeyTypeForDelegate()))

--- a/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/DelegateKeyController.swift
@@ -167,13 +167,14 @@ class DelegateKeyController {
             }
 
         case .walletConnect:
-            let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: safe.chain!)
+            let chain = try? Safe.getSelected()?.chain ?? Chain.mainnetChain()
+            let vc = SignatureRequestToWalletViewController(hexMessage, keyInfo: keyInfo, chain: chain!)
             var isSuccess: Bool = false
-            vc.onSuccess = { [weak self] signature in
+            vc.onSuccess = { signature in
                 isSuccess = true
                 completion(.success(Data(hex: signature)))
             }
-            vc.onCancel = { [weak self] in
+            vc.onCancel = {
                 if !isSuccess {
                     completion(.failure(GSError.AddDelegateKeyCancelled()))
                 }

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
@@ -140,9 +140,9 @@ class RejectionConfirmationViewController: UIViewController {
                 }
             }
         }
-        vc.onCancel = { [weak vc] in
+        vc.onCancel = { [weak self, weak vc] in
             vc?.dismiss(animated: true) {
-                endLoading()
+                self?.endLoading()
             }
         }
         present(vc, animated: true)

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
@@ -133,13 +133,17 @@ class RejectionConfirmationViewController: UIViewController {
         guard presentedViewController == nil else { return }
 
         let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
-        vc.onSuccess = { [weak self] signature in
-            DispatchQueue.main.async {
-                self?.rejectAndCloseController(signature: signature)
+        vc.onSuccess = { [weak self, weak vc] signature in
+            vc?.dismiss(animated: true) {
+                DispatchQueue.main.async {
+                    self?.rejectAndCloseController(signature: signature)
+                }
             }
         }
-        vc.onCancel = { [unowned self] in
-            endLoading()
+        vc.onCancel = { [weak vc] in
+            vc?.dismiss(animated: true) {
+                endLoading()
+            }
         }
         present(vc, animated: true)
     }

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
@@ -132,20 +132,16 @@ class RejectionConfirmationViewController: UIViewController {
     private func rejectWithWalletConnect(_ transaction: Transaction, keyInfo: KeyInfo) {
         guard presentedViewController == nil else { return }
 
-        let pendingConfirmationVC = WCPendingConfirmationViewController(transaction,
-                                                                        keyInfo: keyInfo,
-                                                                        title: "Pending Rejection")
-        pendingConfirmationVC.onClose = { [unowned self] in
-            endLoading()
-        }
-
-        pendingConfirmationVC.sign() { [weak self] signature in
+        let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
+        vc.onSuccess = { [weak self] signature in
             DispatchQueue.main.async {
                 self?.rejectAndCloseController(signature: signature)
             }
         }
-
-        present(pendingConfirmationVC, animated: true)
+        vc.onCancel = { [unowned self] in
+            endLoading()
+        }
+        present(vc, animated: true)
     }
 
     private func startLoading() {

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
@@ -327,11 +327,15 @@ class TransactionDetailsViewController: LoadableViewController, UITableViewDataS
 
         case .walletConnect:
             let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
-            vc.onSuccess = { [weak self] signature in
-                self?.confirmAndRefresh(safeTxHash: safeTxHash, signature: signature, keyType: .walletConnect)
+            vc.onSuccess = { [weak self, weak vc] signature in
+                vc?.dismiss(animated: true) {
+                    self?.confirmAndRefresh(safeTxHash: safeTxHash, signature: signature, keyType: .walletConnect)
+                }
             }
-            vc.onCancel = { [weak self] in
-                self?.reloadData()
+            vc.onCancel = { [weak self, weak vc] in
+                vc?.dismiss(animated: true) {
+                    self?.reloadData()
+                }
             }
             present(vc, animated: true)
 

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
@@ -326,17 +326,14 @@ class TransactionDetailsViewController: LoadableViewController, UITableViewDataS
             }
 
         case .walletConnect:
-            let vc = WCPendingConfirmationViewController(transaction, keyInfo: keyInfo, title: "Confirm Transaction")
-
-            vc.onClose = { [weak self] in
-                self?.reloadData()
-            }
-
-            present(vc, animated: true)
-
-            vc.sign() { [weak self] signature in
+            let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
+            vc.onSuccess = { [weak self] signature in
                 self?.confirmAndRefresh(safeTxHash: safeTxHash, signature: signature, keyType: .walletConnect)
             }
+            vc.onCancel = { [weak self] in
+                self?.reloadData()
+            }
+            present(vc, animated: true)
 
         case .ledgerNanoX:
             let request = SignRequest(title: "Confirm Transaction",

--- a/Multisig/UI/WalletConnect/Server/Safes/Incoming Transaction/WCIncomingTransactionRequestViewController.swift
+++ b/Multisig/UI/WalletConnect/Server/Safes/Incoming Transaction/WCIncomingTransactionRequestViewController.swift
@@ -122,16 +122,18 @@ class WCIncomingTransactionRequestViewController: UIViewController {
 
     private func signWithWalletConnect(_ transaction: Transaction, keyInfo: KeyInfo) {
         guard presentedViewController == nil else { return }
-
-        let pendingConfirmationVC = WCPendingConfirmationViewController(transaction, keyInfo: keyInfo)
-        present(pendingConfirmationVC, animated: true)
-
-        pendingConfirmationVC.sign() { [weak self] signature in
+        
+        let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
+        vc.onSuccess = { [weak self] signature in
             DispatchQueue.global().async {
                 self?.sendConfirmationAndDismiss(signature: signature,
                                                  trackingEvent: .incomingTxConfirmedWalletConnect)
             }
         }
+        vc.onCancel = { [weak self] in
+            
+        }
+        present(vc, animated: true)
     }
 
     private func sendConfirmationAndDismiss(signature: String, trackingEvent: TrackingEvent) {

--- a/Multisig/UI/WalletConnect/Server/Safes/Incoming Transaction/WCIncomingTransactionRequestViewController.swift
+++ b/Multisig/UI/WalletConnect/Server/Safes/Incoming Transaction/WCIncomingTransactionRequestViewController.swift
@@ -124,14 +124,16 @@ class WCIncomingTransactionRequestViewController: UIViewController {
         guard presentedViewController == nil else { return }
         
         let vc = SignatureRequestToWalletViewController(transaction, keyInfo: keyInfo, chain: safe.chain!)
-        vc.onSuccess = { [weak self] signature in
-            DispatchQueue.global().async {
-                self?.sendConfirmationAndDismiss(signature: signature,
-                                                 trackingEvent: .incomingTxConfirmedWalletConnect)
+        vc.onSuccess = { [weak self, weak vc] signature in
+            vc?.dismiss(animated: true) {
+                DispatchQueue.global().async {
+                    self?.sendConfirmationAndDismiss(signature: signature,
+                                                     trackingEvent: .incomingTxConfirmedWalletConnect)
+                }
             }
         }
-        vc.onCancel = { [weak self] in
-            
+        vc.onCancel = { [weak vc] in
+            vc?.dismiss(animated: true)
         }
         present(vc, animated: true)
     }


### PR DESCRIPTION
Handles #2055

Changes proposed in this pull request:
- eth_signTypedData & eth_sign for signing
- Use SignatureRequestToWalletViewController for signing requests
- Use SendTransactionToWalletViewController for send tx requests
- Extract connectivity logic to base class (PendingWalletActionViewController)

TODO: add all wallets that support eth_signTypedData to the switch in wcSign
