### PR TITLE
gh-1505 Fixing the error and crashes

### DIFF
--- a/Multisig/Features/Connect to Wallet/Logic/WCAppRegistryRepository.swift
+++ b/Multisig/Features/Connect to Wallet/Logic/WCAppRegistryRepository.swift
@@ -40,11 +40,18 @@ class WCAppRegistryRepository {
         assert(Thread.isMainThread)
         let context = App.shared.coreDataStack.viewContext
 
+
+
         // delete all existing entries
         guard let cdEntries = (try? CDWCAppRegistryEntry.getAll()) else {
             return
         }
+        var keysByEntry: [String: KeyInfo] = [:]
         for entry in cdEntries {
+            // keep relationship between existing entry and a key
+            if let id = entry.id {
+                keysByEntry[id] = entry.key
+            }
             context.delete(entry)
         }
 
@@ -52,6 +59,8 @@ class WCAppRegistryRepository {
         for entry in entries {
             let cdEntry = CDWCAppRegistryEntry.create()
             update(cdEntry: cdEntry, with: entry)
+            // restore relationship to the key
+            cdEntry.key = keysByEntry[entry.id]
         }
 
         App.shared.coreDataStack.saveContext()

--- a/Multisig/Features/Connect to Wallet/UI/PendingWalletActionViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/PendingWalletActionViewController.swift
@@ -26,11 +26,15 @@ class PendingWalletActionViewController: ContainerViewController, UIAdaptivePres
     var requestTimeout: TimeInterval = 120
 
     var walletName: String {
-        wallet?.name ?? connection.remotePeer?.name ?? "wallet"
+        wallet?.name ?? connection?.remotePeer?.name ?? "wallet"
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        if let keyInfo = keyInfo, connection == nil {
+            connection = WebConnectionController.shared.walletConnection(keyInfo: keyInfo).first
+        }
         
         let placeholder = UIImage(named: "ico-wallet-placeholder")
         walletImage.setImage(

--- a/Multisig/Features/Connect to Wallet/UI/SendTransactionToWalletViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/SendTransactionToWalletViewController.swift
@@ -18,7 +18,7 @@ class SendTransactionToWalletViewController: PendingWalletActionViewController {
 
     convenience init(transaction: Client.Transaction, keyInfo: KeyInfo, chain: Chain) {
         self.init(namedClass: PendingWalletActionViewController.self)
-        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.wallet = keyInfo.wallet.flatMap { WCAppRegistryRepository().entry(from: $0) }
         self.keyInfo = keyInfo
         self.transaction = transaction
         self.chain = chain

--- a/Multisig/Features/Connect to Wallet/UI/SignatureRequestToWalletViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/SignatureRequestToWalletViewController.swift
@@ -21,7 +21,7 @@ class SignatureRequestToWalletViewController: PendingWalletActionViewController 
 
     convenience init(_ transaction: Client.Transaction, keyInfo: KeyInfo, chain: Chain) {
         self.init(namedClass: PendingWalletActionViewController.self)
-        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.wallet = keyInfo.wallet.flatMap { WCAppRegistryRepository().entry(from: $0) }
         self.keyInfo = keyInfo
         self.clientTransaction = transaction
         self.chain = chain
@@ -29,7 +29,7 @@ class SignatureRequestToWalletViewController: PendingWalletActionViewController 
     
     convenience init(_ transaction: Transaction, keyInfo: KeyInfo, chain: Chain, isRejection: Bool = false) {
         self.init(namedClass: PendingWalletActionViewController.self)
-        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.wallet = keyInfo.wallet.flatMap { WCAppRegistryRepository().entry(from: $0) }
         self.keyInfo = keyInfo
         self.transaction = transaction
         self.isRejection = isRejection
@@ -38,7 +38,7 @@ class SignatureRequestToWalletViewController: PendingWalletActionViewController 
     
     convenience init(_ message: String, keyInfo: KeyInfo, chain: Chain) {
         self.init(namedClass: PendingWalletActionViewController.self)
-        self.wallet = WCAppRegistryRepository().entry(from: keyInfo.wallet!)
+        self.wallet = keyInfo.wallet.flatMap { WCAppRegistryRepository().entry(from: $0) }
         self.keyInfo = keyInfo
         self.message = message
         self.chain = chain

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -167,39 +167,43 @@ class OwnerKeyDetailsViewController: UITableViewController, WebConnectionObserve
     }
 
     @objc private func reloadData() {
-        DispatchQueue.main.async { [unowned self] in
-            // it may happen that key info is updated in the CoreData but the current managed object
-            // that we retained here is not updated.
-            if let key = keyInfo {
-                keyInfo = try? KeyInfo.firstKey(address: key.address)
-            }
-
-            self.sections = [
-                (section: .name("OWNER NAME"), items: [Section.Name.name]),
-
-                (section: .keyAddress("OWNER ADDRESS"),
-                        items: [Section.KeyAddress.address]),
-
-                (section: .ownerKeyType("OWNER TYPE"),
-                        items: [Section.OwnerKeyType.type])]
-
-            if self.keyInfo.keyType == .walletConnect {
-                self.sections.append((section: .connected("WC CONNECTION"), items: [Section.Connected.connected]))
-            }
-
-            if [.walletConnect, .ledgerNanoX].contains(keyInfo.keyType) {
-                self.sections.append((section: .pushNotificationConfiguration("PUSH NOTIFICATIONS"),
-                        items: [Section.PushNotificationConfiguration.enabled]))
-                if self.keyInfo.delegateAddress != nil {
-                    self.sections.append((section: .delegateKey("DELEGATE KEY ADDRESS"),
-                            items: [Section.DelegateKey.address, Section.DelegateKey.helpLink]))
-                }
-            }
-
-            self.sections.append((section: .advanced, items: [Section.Advanced.remove]))
-
-            self.tableView.reloadData()
+        DispatchQueue.main.async { [weak self] in
+            self?.doReloadData()
         }
+    }
+
+    private func doReloadData() {
+        // it may happen that key info is updated in the CoreData but the current managed object
+        // that we retained here is not updated.
+        if let key = keyInfo {
+            keyInfo = try? KeyInfo.firstKey(address: key.address)
+        }
+
+        self.sections = [
+            (section: .name("OWNER NAME"), items: [Section.Name.name]),
+
+            (section: .keyAddress("OWNER ADDRESS"),
+                    items: [Section.KeyAddress.address]),
+
+            (section: .ownerKeyType("OWNER TYPE"),
+                    items: [Section.OwnerKeyType.type])]
+
+        if self.keyInfo.keyType == .walletConnect {
+            self.sections.append((section: .connected("WC CONNECTION"), items: [Section.Connected.connected]))
+        }
+
+        if [.walletConnect, .ledgerNanoX].contains(keyInfo.keyType) {
+            self.sections.append((section: .pushNotificationConfiguration("PUSH NOTIFICATIONS"),
+                    items: [Section.PushNotificationConfiguration.enabled]))
+            if self.keyInfo.delegateAddress != nil {
+                self.sections.append((section: .delegateKey("DELEGATE KEY ADDRESS"),
+                        items: [Section.DelegateKey.address, Section.DelegateKey.helpLink]))
+            }
+        }
+
+        self.sections.append((section: .advanced, items: [Section.Advanced.remove]))
+
+        self.tableView.reloadData()
     }
 
     @objc private func pop() {


### PR DESCRIPTION
- Wallet is optional
- Wallet was lost when entry registries recreated

Handles #1505 

Changes proposed in this pull request:
- Wallet made optional in sign/sendtx requests
- Restore the key-entry relationship when entries are recreated during connecting multiple wallets