### PR TITLE
Gh 1783/fix gray out and error

### DIFF
--- a/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
@@ -9,6 +9,7 @@ import Ethereum
 import Solidity
 import WalletConnectSwift
 import JsonRpc2
+import Json
 
 class SendTransactionRequestViewController: WebConnectionContainerViewController, WebConnectionRequestObserver {
 
@@ -544,7 +545,8 @@ class SendTransactionRequestViewController: WebConnectionContainerViewController
             }
 
             if let error = response.error {
-                dispatchOnMainThread(completion(.failure(error)))
+                let jsonError = (try? error.data?.convert(to: Json.NSError.self))?.nsError() ?? (error as NSError)
+                dispatchOnMainThread(completion(.failure(jsonError)))
                 return
             }
 

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeFormUIModel.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeFormUIModel.swift
@@ -13,6 +13,7 @@ import SwiftCryptoTokenFormatter
 import SafeDeployments
 import SafeAbi
 import JsonRpc2
+import Json
 
 protocol CreateSafeFormUIModelDelegate: AnyObject {
     func updateUI(model: CreateSafeFormUIModel)
@@ -645,7 +646,8 @@ class CreateSafeFormUIModel {
             }
 
             if let error = response.error {
-                dispatchOnMainThread(completion(.failure(error)))
+                let jsonError = (try? error.data?.convert(to: Json.NSError.self))?.nsError() ?? (error as NSError)
+                dispatchOnMainThread(completion(.failure(jsonError)))
                 return
             }
 

--- a/Multisig/UI/Settings/OwnerKeyManagement/ChooseOwnerKeyViewController/ChooseOwnerKeyViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/ChooseOwnerKeyViewController/ChooseOwnerKeyViewController.swift
@@ -170,7 +170,7 @@ class ChooseOwnerKeyViewController: UIViewController {
                     return
                 }
                 LogService.shared.error("Balances loading failed: \(error)")
-                let gsError = GSError.error(description: "Failed to load account balances")
+                let gsError = GSError.error(description: "Failed to load account balances", error: error)
                 App.shared.snackbar.show(error: gsError)
 
             case .success(let balances):

--- a/Multisig/UI/Transaction/Execution/DefaultAccountBalanceLoader.swift
+++ b/Multisig/UI/Transaction/Execution/DefaultAccountBalanceLoader.swift
@@ -76,7 +76,8 @@ class DefaultAccountBalanceLoader: AccountBalanceLoader {
                 dispatchOnMainThread(completion(.failure(gsError)))
 
             case .response(let response):
-                let gsError = GSError.error(description: serverErrorMessage, error: response.error)
+                let jsonError = (try? response.error?.data?.convert(to: Json.NSError.self))?.nsError() ?? (response.error as NSError?)
+                let gsError = GSError.error(description: serverErrorMessage, error: jsonError)
                 dispatchOnMainThread(completion(.failure(gsError)))
 
             case .array(let responses):
@@ -120,7 +121,9 @@ class DefaultAccountBalanceLoader: AccountBalanceLoader {
                             )
 
                             model.displayAmount = "\(value) \(nativeCoinSymbol)"
-                            model.isEnabled = balance >= requiredBalance
+                            model.isEnabled = balance >= requiredBalance && requiredBalance > 0
+                        } else {
+                            model.isEnabled = false
                         }
 
                         return model

--- a/Multisig/UI/Transaction/Execution/DefaultAccountBalanceLoader.swift
+++ b/Multisig/UI/Transaction/Execution/DefaultAccountBalanceLoader.swift
@@ -121,9 +121,7 @@ class DefaultAccountBalanceLoader: AccountBalanceLoader {
                             )
 
                             model.displayAmount = "\(value) \(nativeCoinSymbol)"
-                            model.isEnabled = balance >= requiredBalance && requiredBalance > 0
-                        } else {
-                            model.isEnabled = false
+                            model.isEnabled = balance >= requiredBalance
                         }
 
                         return model

--- a/Multisig/UI/Transaction/Execution/TransactionEstimationController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionEstimationController.swift
@@ -10,6 +10,7 @@ import Foundation
 import Ethereum
 import JsonRpc2
 import Solidity
+import Json
 
 class TransactionEstimationController {
 
@@ -103,7 +104,8 @@ class TransactionEstimationController {
             case .response(let response):
                 // single response is a failed batch request
                 if let error = response.error {
-                    dispatchOnMainThread(completion(.failure(error)))
+                    let jsonError = (try? error.data?.convert(to: Json.NSError.self))?.nsError() ?? (error as NSError)
+                    dispatchOnMainThread(completion(.failure(jsonError)))
                 } else {
                     dispatchOnMainThread(completion(.failure(TransactionEstimationError(code: -2, message: "Failed to estimate transaction."))))
                 }

--- a/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
+++ b/Multisig/UI/Transaction/Execution/TransactionExecutionController.swift
@@ -15,6 +15,7 @@ import Web3
 import JsonRpc2
 import CryptoSwift
 import WalletConnectSwift
+import Json
 
 struct UserDefinedTransactionParameters: Equatable {
     var nonce: Sol.UInt64?
@@ -573,7 +574,8 @@ class TransactionExecutionController {
             }
 
             if let error = response.error {
-                dispatchOnMainThread(completion(.failure(error)))
+                let jsonError = (try? error.data?.convert(to: Json.NSError.self))?.nsError() ?? (error as NSError)
+                dispatchOnMainThread(completion(.failure(jsonError)))
                 return
             }
 


### PR DESCRIPTION
Handles #1783

Changes proposed in this pull request:
- The gray out is won't fix for when tx estimation fails. The reason is that the required balance for failed tx estimation is 0 eth, so this is a valid case in my opinion. If I prohibit using a key when the required balance is 0 then potentially this will have errors in future situations. Some networks might make the fees as 0, so the transaction would still be valid. 
- Show message from the NSError when encountered during JSON RPC call.