### PR TITLE
Gh 2148/ipad camera rotation

### DIFF
--- a/Multisig/UI/UI Library/View Controllers/QRCodeScannerViewController/QRCodeScannerViewController.swift
+++ b/Multisig/UI/UI Library/View Controllers/QRCodeScannerViewController/QRCodeScannerViewController.swift
@@ -52,7 +52,31 @@ class QRCodeScannerViewController: UIViewController {
         if captureSession?.isRunning == false {
             captureSession.startRunning()
         }
+
         Tracker.trackEvent(.camera, parameters: trackingParameters)
+
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // We have to rotate the preview layer to the current interface orientation because it always starts
+        // in the 'portrait' orientation.
+
+        switch self.view.window?.windowScene?.interfaceOrientation {
+        case .portrait:
+            previewLayer.transform = CATransform3DMakeRotation(0, 0, 0, 1)
+        case .portraitUpsideDown:
+            previewLayer.transform = CATransform3DMakeRotation(CGFloat.pi, 0, 0, 1)
+        case .landscapeLeft:
+            previewLayer.transform = CATransform3DMakeRotation(CGFloat.pi / 2, 0, 0, 1)
+        case .landscapeRight:
+            previewLayer.transform = CATransform3DMakeRotation(-CGFloat.pi / 2, 0, 0, 1)
+        default:
+            break
+        }
+
+        // We've rotated the view, so the width/height might not be correct anymore. Re-apply the width/hight settings.
+        previewLayer?.frame = view.layer.bounds
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -62,7 +86,29 @@ class QRCodeScannerViewController: UIViewController {
             captureSession.stopRunning()
         }
     }
-    
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        previewLayer?.frame = view.layer.bounds
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        if let layer = previewLayer {
+            // Rotate the preview layer to the new orientation.
+            // NOTE: to understand what transformation matrices are and how to rotate coordinates,
+            // see https://www.youtube.com/watch?v=kYB8IZa5AuE
+
+            // convert from Core Graphics 2D transform matrix to Core Animation 3D transform matrix
+            let newOrientation = CATransform3DMakeAffineTransform(coordinator.targetTransform)
+            // Apply transformation (rotation to new orientation) to the current transform matrix
+            let currentInterfaceRotatedToNewOrientation = CATransform3DConcat(newOrientation, layer.transform)
+            // Somehow camera appears to be flipped by 180 degrees after rotation, so rotate it back
+            let flippedBy180Degrees = CATransform3DRotate(currentInterfaceRotatedToNewOrientation, -CGFloat.pi, 0, 0, 1)
+            layer.transform = flippedBy180Degrees
+        }
+    }
+
     @IBAction func closeButtonTouched(_ sender: Any) {
         delegate?.scannerViewControllerDidCancel()
     }
@@ -118,7 +164,7 @@ class QRCodeScannerViewController: UIViewController {
 
         captureSession.startRunning()
     }
-    
+
     private func presentCameraAccessRequiredAlert() {
         let settingsAppURL = URL(string: UIApplication.openSettingsURLString)!
         let alert = UIAlertController(


### PR DESCRIPTION
Handles #2148
Handles #2149


Changes proposed in this pull request:
- Apply correct transformation matrix when view is on screen and after interface rotation
- Tell that camera is unavailable if the camera stream is interrupted
