### PR TITLE
gh-2194 Fix crash when removing wc key from list

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -178,6 +178,10 @@ class OwnerKeyDetailsViewController: UITableViewController, WebConnectionObserve
         if let key = keyInfo {
             keyInfo = try? KeyInfo.firstKey(address: key.address)
         }
+        
+        guard let keyInfo = keyInfo else {
+            return
+        }
 
         self.sections = [
             (section: .name("OWNER NAME"), items: [Section.Name.name]),
@@ -188,7 +192,7 @@ class OwnerKeyDetailsViewController: UITableViewController, WebConnectionObserve
             (section: .ownerKeyType("OWNER TYPE"),
                     items: [Section.OwnerKeyType.type])]
 
-        if self.keyInfo.keyType == .walletConnect {
+        if keyInfo.keyType == .walletConnect {
             self.sections.append((section: .connected("WC CONNECTION"), items: [Section.Connected.connected]))
         }
 

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeysListViewController/OwnerKeysListViewController.swift
@@ -97,7 +97,7 @@ class OwnerKeysListViewController: LoadableViewController, UITableViewDelegate, 
         tableView.deselectRow(at: indexPath, animated: true)
         let keyInfo = keys[indexPath.row]
         let vc = OwnerKeyDetailsViewController(keyInfo: keyInfo)
-        show(vc, sender: nil)
+        show(vc, sender: self)
     }
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {


### PR DESCRIPTION
Handles #2194

Changes proposed in this pull request:
- Quick & dirty solution 
- Actual reason for reloadData being triggered after key details page was closed is still under investigation. When key is removed  keyInfo will be nil and this leads to crash mentioned in the ticket

