### PR TITLE
Gh 2326 - unhide too early

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddKeyAsOwnerIntroViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddKeyAsOwnerIntroViewController.swift
@@ -35,7 +35,7 @@ class AddKeyAsOwnerIntroViewController: UIViewController, UIAdaptivePresentation
 
         // disable swipe back
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
-        
+
         navigationController?.isNavigationBarHidden = false
 
         titleLabel.setStyle(.primary)

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddOwnerFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddOwnerFlow.swift
@@ -16,15 +16,16 @@ class AddOwnerFlow: UIFlow {
     var newConfirmations: Int?
     var addOwnerTransactionDetails: SCGModels.TransactionDetails?
 
-    init(newOwner: AddressInfo, safe: Safe, factory: AddOwnerFlowFactory = .init(), navigationController: UINavigationController, completion: @escaping (_ success: Bool) -> Void) {
+    init(newOwner: AddressInfo, safe: Safe, factory: AddOwnerFlowFactory = .init(), navigationController: UINavigationController, presenter: UIViewController? = nil, completion: @escaping (_ success: Bool) -> Void) {
         self.factory = factory
         self.safe = safe
         self.newOwner = newOwner
-        super.init(navigationController: navigationController, completion: completion)
+        super.init(navigationController: navigationController, presenter: presenter, completion: completion)
     }
 
     override func start() {
         confirmations()
+        super.start()
     }
 
     func confirmations() {

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/RemoveOwnerFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/RemoveOwnerFlow.swift
@@ -16,16 +16,17 @@ class RemoveOwnerFlow: UIFlow {
     var newConfirmations: Int?
     var removeOwnerTransactionDetails: SCGModels.TransactionDetails?
 
-    internal init(owner: Address, prevOwner: Address?, safe: Safe, factory: RemoveOwnerFlowFactory = .init(), navigationController: UINavigationController, completion: @escaping (_ success: Bool) -> Void) {
+    internal init(owner: Address, prevOwner: Address?, safe: Safe, factory: RemoveOwnerFlowFactory = .init(), navigationController: UINavigationController,  presenter: UIViewController? = nil, completion: @escaping (_ success: Bool) -> Void) {
         self.factory = factory
         self.safe = safe
         self.ownerToRemove = owner
         self.prevOwner = prevOwner
-        super.init(navigationController: navigationController, completion: completion)
+        super.init(navigationController: navigationController, presenter: presenter, completion: completion)
     }
 
     override func start() {
         confirmations()
+        super.start()
     }
 
     func confirmations() {

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKey/EnterOwnerAddressViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKey/EnterOwnerAddressViewController.swift
@@ -94,15 +94,16 @@ class EnterOwnerAddressViewController: UIViewController {
 
     private func startAddOwnerFlow(address: Address, name: String) {
         addOwnerFlow =
-            AddOwnerFlow(
-                newOwner: AddressInfo(address: address, name: name),
-                safe: safe!,
-                factory: AddOwnerFlowFromSettingsFactory(),
-                navigationController: navigationController!) { [unowned self] skippedTxDetails in
+                AddOwnerFlow(
+                        newOwner: AddressInfo(address: address, name: name),
+                        safe: safe!,
+                        factory: AddOwnerFlowFromSettingsFactory(),
+                        navigationController: navigationController!,
+                        completion: { [unowned self] skippedTxDetails in
                     addOwnerFlow = nil
                     //TODO: pass parameters if needed
                     self.completion()
-                }
+                })
         addOwnerFlow.start()
     }
 

--- a/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
@@ -33,7 +33,30 @@ class UIFlow {
             navigationController.show(vc, sender: navigationController)
         }
     }
+}
 
+class ModalUIFLow : UIFlow {
+
+    weak var presenter: UIViewController!
+
+     init(presenter: UIViewController, navigationController: UINavigationController, completion: @escaping (_ success: Bool) -> Void) {
+         self.presenter = presenter
+         super.init(navigationController: navigationController, completion: completion)
+    }
+
+    override func start() {
+
+        // guaranteed to exist at this point
+        let rootVC = navigationController.viewControllers.first!
+        ViewControllerFactory.addCloseButton(rootVC)
+        presenter.present(navigationController, animated: true)
+    }
+
+    override func stop(success: Bool) {
+        presenter.dismiss(animated: true) { [unowned self] in
+            completion(success)
+        }
+    }
 }
 
 //

--- a/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
@@ -12,18 +12,31 @@ class UIFlow {
 
     var navigationController: UINavigationController
     var completion: (_ success: Bool) -> Void
+    weak var presenter: UIViewController?
 
-    internal init(navigationController: UINavigationController, completion: @escaping (_ success: Bool) -> Void) {
+    internal init(navigationController: UINavigationController, presenter: UIViewController? = nil, completion: @escaping (_ success: Bool) -> Void) {
         self.navigationController = navigationController
         self.completion = completion
+        self.presenter = presenter
     }
 
     func start() {
-
+        if let presenter = presenter {
+            // guaranteed to exist at this point
+            let rootVC = navigationController.viewControllers.first!
+            ViewControllerFactory.addCloseButton(rootVC)
+            presenter.present(navigationController, animated: true)
+        }
     }
 
     func stop(success: Bool) {
-        completion(success)
+        if let presenter = presenter {
+            presenter.dismiss(animated: true) { [unowned self] in
+                completion(success)
+            }
+        } else {
+            completion(success)
+        }
     }
 
     func show(_ vc: UIViewController) {
@@ -31,30 +44,6 @@ class UIFlow {
             navigationController.viewControllers = [vc]
         } else {
             navigationController.show(vc, sender: navigationController)
-        }
-    }
-}
-
-class ModalUIFLow : UIFlow {
-
-    weak var presenter: UIViewController!
-
-     init(presenter: UIViewController, navigationController: UINavigationController, completion: @escaping (_ success: Bool) -> Void) {
-         self.presenter = presenter
-         super.init(navigationController: navigationController, completion: completion)
-    }
-
-    override func start() {
-
-        // guaranteed to exist at this point
-        let rootVC = navigationController.viewControllers.first!
-        ViewControllerFactory.addCloseButton(rootVC)
-        presenter.present(navigationController, animated: true)
-    }
-
-    override func stop(success: Bool) {
-        presenter.dismiss(animated: true) { [unowned self] in
-            completion(success)
         }
     }
 }
@@ -79,7 +68,7 @@ class BackupFlow: UIFlow {
     var mnemonic: String
     var factory: BackupFlowFactory
 
-    init(mnemonic: String, factory: BackupFlowFactory = BackupFlowFactory(), navigationController: UINavigationController, completion: @escaping (_ success: Bool) -> Void) {
+    init(mnemonic: String, factory: BackupFlowFactory = BackupFlowFactory(), navigationController: UINavigationController, presenter: UIViewController? = nil, completion: @escaping (_ success: Bool) -> Void) {
         self.mnemonic = mnemonic
         self.factory = factory
         super.init(navigationController: navigationController, completion: completion)
@@ -139,8 +128,6 @@ class ModalBackupFlow: BackupFlow {
     //                    \
     //                     -> canceled
 
-    weak var presenter: UIViewController!
-
     convenience init?(keyInfo: KeyInfo, presenter: UIViewController, factory: BackupFlowFactory = BackupFlowFactory(), completion: @escaping (_ success: Bool) -> Void) {
         guard let mnemonic = try? keyInfo.privateKey()?.mnemonic else {
             return nil
@@ -149,11 +136,11 @@ class ModalBackupFlow: BackupFlow {
     }
 
     init(mnemonic: String, presenter: UIViewController, factory: BackupFlowFactory = BackupFlowFactory(), completion: @escaping (_ success: Bool) -> Void) {
-        self.presenter = presenter
         let navigationController = CancellableNavigationController()
         super.init(mnemonic: mnemonic,
                    factory: factory,
                    navigationController: navigationController,
+                   presenter: presenter,
                    completion: completion)
 
         navigationController.onCancel = { [unowned self] in
@@ -163,10 +150,7 @@ class ModalBackupFlow: BackupFlow {
 
     override func start() {
         passcode()
-        // guaranteed to exist at this point
-        let rootVC = navigationController.viewControllers.first!
-        ViewControllerFactory.addCloseButton(rootVC)
-        presenter.present(navigationController, animated: true)
+        super.start()
     }
 
     func passcode() {
@@ -191,12 +175,6 @@ class ModalBackupFlow: BackupFlow {
         super.seed()
         guard let vc = navigationController.viewControllers.last else { return }
         ViewControllerFactory.addCloseButton(vc)
-    }
-
-    override func stop(success: Bool) {
-        presenter.dismiss(animated: true) { [unowned self] in
-            completion(success)
-        }
     }
 }
 

--- a/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
@@ -71,11 +71,12 @@ class BackupFlow: UIFlow {
     init(mnemonic: String, factory: BackupFlowFactory = BackupFlowFactory(), navigationController: UINavigationController, presenter: UIViewController? = nil, completion: @escaping (_ success: Bool) -> Void) {
         self.mnemonic = mnemonic
         self.factory = factory
-        super.init(navigationController: navigationController, completion: completion)
+        super.init(navigationController: navigationController, presenter: presenter, completion: completion)
     }
 
     override func start() {
         intro()
+        super.start()
     }
 
     func intro() {

--- a/Multisig/UI/Settings/OwnerKeyManagement/GenerateOwnerKey/GenerateKeyFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/GenerateOwnerKey/GenerateKeyFlow.swift
@@ -150,7 +150,7 @@ class GenerateKeyFactory: AddKeyFlowFactory {
         return introVC
     }
 
-    func details(keyInfo: KeyInfo, completion: @escaping () -> Void) -> OwnerKeyDetailsViewController  {
+    func details(keyInfo: KeyInfo, completion: @escaping () -> Void) -> OwnerKeyDetailsViewController {
         OwnerKeyDetailsViewController(keyInfo: keyInfo, completion: completion)
     }
 }

--- a/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ChangeConfirmationsFlow.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ChangeConfirmationsFlow.swift
@@ -12,11 +12,11 @@ class ChangeConfirmationsFlow: UIFlow {
     var newConfirmations: Int?
     var changeConfirmationsTransactionDetails: SCGModels.TransactionDetails?
 
-    init(safe: Safe, presenter: UIViewController, factory: ChangeConfirmationsFlowFactory = .init(), completion: @escaping (_ success: Bool) -> Void) {
+    init(safe: Safe, factory: ChangeConfirmationsFlowFactory = .init(), presenter: UIViewController, completion: @escaping (Bool) -> ()) {
         self.factory = factory
         self.safe = safe
         let navigationController = CancellableNavigationController()
-        super.init( navigationController: navigationController, presenter: presenter, completion: completion)
+        super.init(navigationController: navigationController, presenter: presenter, completion: completion)
         navigationController.onCancel = { [unowned self] in
             stop(success: false)
         }

--- a/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ChangeConfirmationsFlow.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ChangeConfirmationsFlow.swift
@@ -6,19 +6,17 @@
 import Foundation
 import UIKit
 
-class ChangeConfirmationsFlow: UIFlow {
+class ChangeConfirmationsFlow: ModalUIFLow {
     var factory: ChangeConfirmationsFlowFactory
     var safe: Safe
     var newConfirmations: Int?
     var changeConfirmationsTransactionDetails: SCGModels.TransactionDetails?
-    weak var presenter: UIViewController!
 
     init(safe: Safe, presenter: UIViewController, factory: ChangeConfirmationsFlowFactory = .init(), completion: @escaping (_ success: Bool) -> Void) {
         self.factory = factory
         self.safe = safe
-        self.presenter = presenter
         let navigationController = CancellableNavigationController()
-        super.init(navigationController: navigationController, completion: completion)
+        super.init(presenter: presenter, navigationController: navigationController, completion: completion)
         navigationController.onCancel = { [unowned self] in
             stop(success: false)
         }
@@ -65,16 +63,7 @@ class ChangeConfirmationsFlow: UIFlow {
 
     override func start() {
         confirmations()
-        // guaranteed to exist at this point
-        let rootVC = navigationController.viewControllers.first!
-        ViewControllerFactory.addCloseButton(rootVC)
-        presenter.present(navigationController, animated: true)
-    }
-
-    override func stop(success: Bool) {
-        presenter.dismiss(animated: true) { [unowned self] in
-            completion(success)
-        }
+        super.start()
     }
 }
 

--- a/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ChangeConfirmationsFlow.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ChangeConfirmationsFlow.swift
@@ -6,7 +6,7 @@
 import Foundation
 import UIKit
 
-class ChangeConfirmationsFlow: ModalUIFLow {
+class ChangeConfirmationsFlow: UIFlow {
     var factory: ChangeConfirmationsFlowFactory
     var safe: Safe
     var newConfirmations: Int?
@@ -16,7 +16,7 @@ class ChangeConfirmationsFlow: ModalUIFLow {
         self.factory = factory
         self.safe = safe
         let navigationController = CancellableNavigationController()
-        super.init(presenter: presenter, navigationController: navigationController, completion: completion)
+        super.init( navigationController: navigationController, presenter: presenter, completion: completion)
         navigationController.onCancel = { [unowned self] in
             stop(success: false)
         }

--- a/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ReviewChangeConfirmationsTxViewController.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/ChangeConfirmations/ReviewChangeConfirmationsTxViewController.swift
@@ -81,7 +81,6 @@ class ReviewChangeConfirmationsTxViewController: ReviewSafeTransactionViewContro
         return cell
     }
 
-
     override func onSuccess(transaction: SCGModels.TransactionDetails) {
         onSuccess?(transaction)
     }

--- a/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
@@ -333,12 +333,12 @@ class SafeSettingsViewController: LoadableViewController, UITableViewDelegate, U
     }
 
     func remove(owner: Address, prevOwner: Address?) {
-        let navigationController = CancellableNavigationController()
+        let cancellableNavigationController = CancellableNavigationController()
         removeOwnerFlow = RemoveOwnerFlow(
                 owner: owner,
                 prevOwner: prevOwner,
                 safe: safe!,
-                navigationController: navigationController,
+                navigationController: cancellableNavigationController,
                 presenter: self,
                 completion: { [unowned self] _ in
                     removeOwnerFlow = nil
@@ -475,6 +475,7 @@ class SafeSettingsViewController: LoadableViewController, UITableViewDelegate, U
                 let enterOwnerAddressVC = EnterOwnerAddressViewController()
                 enterOwnerAddressVC.completion = { [unowned self] in
                     //TODO Open key details?
+                    self.dismiss(animated: false)
                 }
                 ViewControllerFactory.addCloseButton(enterOwnerAddressVC)
                 let vc = UINavigationController(rootViewController: enterOwnerAddressVC)

--- a/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
+++ b/Multisig/UI/Settings/SafeSettingsViewController/SafeSettingsViewController.swift
@@ -312,14 +312,14 @@ class SafeSettingsViewController: LoadableViewController, UITableViewDelegate, U
         case Section.OwnerAddresses.ownerInfo(let info):
             guard let ownerIndex = (safeOwners.firstIndex { $0.address == info.address }) else { return nil }
             let prevOwner = safeOwners.before(ownerIndex)
-            let deleteAction = UIContextualAction(style: .destructive, title : "Remove") {
+            let deleteAction = UIContextualAction(style: .destructive, title: "Remove") {
                 [unowned self] _, _, completion in
                 self.remove(owner: info.address, prevOwner: prevOwner?.address)
                 completion(true)
             }
             deleteAction.backgroundColor = .error
 
-            let replaceAction = UIContextualAction(style: .normal, title : "Replace") {
+            let replaceAction = UIContextualAction(style: .normal, title: "Replace") {
                 [unowned self] _, _, completion in
                 // TODO: Display replace owner flow
                 completion(true)
@@ -333,17 +333,17 @@ class SafeSettingsViewController: LoadableViewController, UITableViewDelegate, U
     }
 
     func remove(owner: Address, prevOwner: Address?) {
-        guard let navigationController = navigationController else {
-            return
-        }
-
+        let navigationController = CancellableNavigationController()
         removeOwnerFlow = RemoveOwnerFlow(
-            owner: owner,
-            prevOwner: prevOwner,
-            safe: safe!,
-            navigationController: navigationController) { [unowned self] _ in
-                removeOwnerFlow = nil
-            }
+                owner: owner,
+                prevOwner: prevOwner,
+                safe: safe!,
+                navigationController: navigationController,
+                presenter: self,
+                completion: { [unowned self] _ in
+                    removeOwnerFlow = nil
+                }
+        )
         removeOwnerFlow.start()
     }
 
@@ -528,7 +528,7 @@ extension BidirectionalCollection {
             if firstItem {
                 return nil
             } else {
-                return self[index(before:itemIndex)]
+                return self[index(before: itemIndex)]
             }
         }
         return nil

--- a/Multisig/UI/Transaction/ExecuteTransaction/SuccessViewController.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/SuccessViewController.swift
@@ -25,7 +25,6 @@ class SuccessViewController: UIViewController {
 
     var trackingParams: [String: Any]? = nil
 
-    var hidesNavigationBar: Bool = true
     var onDone: (_ didTapPrimary: Bool) -> Void = { _ in }
     
     convenience init(
@@ -88,7 +87,6 @@ class SuccessViewController: UIViewController {
     }
 
     @IBAction func viewDetailsClicked(_ sender: Any) {
-        self.navigationController?.isNavigationBarHidden = false
         onDone(true)
     }
 }


### PR DESCRIPTION
Handles #2326 

Changes proposed in this pull request:
- do not unhide inside success screen
- add modal logic to UIFlow 
- enable and disable modal logic based on whether the presnter is nil

I considered having a ModalUIFlow base class. But we need most of the Flows in both variants.
I was looking for mixins or traits for Swift. 
Protocols can have default implementations, but those can only access to members. I couldn't make it work. The easiest was to decide in UIFlow by chekcing the presenter not to be nil.