### PR TITLE
gh-2347 Added validation and route for add owner request

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -424,6 +424,8 @@
 		0AADCDB828589DCC00A0139B /* AddOwnerExceptionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AADCDB628589DCC00A0139B /* AddOwnerExceptionViewController.xib */; };
 		0AADCDBB2858AA4700A0139B /* InactiveLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AADCDB92858AA4700A0139B /* InactiveLinkViewController.swift */; };
 		0AADCDBC2858AA4700A0139B /* InactiveLinkViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0AADCDBA2858AA4700A0139B /* InactiveLinkViewController.xib */; };
+		0AADCDBE2858CD3800A0139B /* AddOwnerRequestUrlValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AADCDBD2858CD3800A0139B /* AddOwnerRequestUrlValidator.swift */; };
+		0AADCDC02858CE2600A0139B /* AddOwnerRequestValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AADCDBF2858CE2600A0139B /* AddOwnerRequestValidatorTests.swift */; };
 		0AB34D5E24B71CF700A43988 /* DateDecodingStrategy+GnosisSafeServices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB34D5D24B71CF700A43988 /* DateDecodingStrategy+GnosisSafeServices.swift */; };
 		0AB34D6624B71DE300A43988 /* CollectiblesRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB34D6524B71DE300A43988 /* CollectiblesRequest.swift */; };
 		0AB5DF8F270DD185005BFB43 /* CreateDelegateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AB5DF8E270DD185005BFB43 /* CreateDelegateRequest.swift */; };
@@ -1245,6 +1247,8 @@
 		0AADCDB628589DCC00A0139B /* AddOwnerExceptionViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddOwnerExceptionViewController.xib; sourceTree = "<group>"; };
 		0AADCDB92858AA4700A0139B /* InactiveLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactiveLinkViewController.swift; sourceTree = "<group>"; };
 		0AADCDBA2858AA4700A0139B /* InactiveLinkViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = InactiveLinkViewController.xib; sourceTree = "<group>"; };
+		0AADCDBD2858CD3800A0139B /* AddOwnerRequestUrlValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOwnerRequestUrlValidator.swift; sourceTree = "<group>"; };
+		0AADCDBF2858CE2600A0139B /* AddOwnerRequestValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddOwnerRequestValidatorTests.swift; sourceTree = "<group>"; };
 		0AB34D5D24B71CF700A43988 /* DateDecodingStrategy+GnosisSafeServices.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateDecodingStrategy+GnosisSafeServices.swift"; sourceTree = "<group>"; };
 		0AB34D6524B71DE300A43988 /* CollectiblesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectiblesRequest.swift; sourceTree = "<group>"; };
 		0AB5DF8E270DD185005BFB43 /* CreateDelegateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDelegateRequest.swift; sourceTree = "<group>"; };
@@ -2102,6 +2106,7 @@
 			children = (
 				551DDEEA244F192300C719D3 /* Models */,
 				0A9366BC279090CC001918A9 /* OwnerKeySelectionPolicyTests.swift */,
+				0AADCDBF2858CE2600A0139B /* AddOwnerRequestValidatorTests.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -3558,6 +3563,7 @@
 				0AADCDBA2858AA4700A0139B /* InactiveLinkViewController.xib */,
 				0AADCDB528589DCC00A0139B /* AddOwnerExceptionViewController.swift */,
 				0AADCDB628589DCC00A0139B /* AddOwnerExceptionViewController.xib */,
+				0AADCDBD2858CD3800A0139B /* AddOwnerRequestUrlValidator.swift */,
 				0ABC00272823BE6800F42D29 /* AddOwnerFlow.swift */,
 				045A17602833DCF30020484B /* AddOwnerFlowFromSettings.swift */,
 				0ABC00292823D4CD00F42D29 /* ReplaceOwnerFlow.swift */,
@@ -4504,6 +4510,7 @@
 				0AE0AFEC2805C6B9002594CB /* VerifyPhraseViewController.swift in Sources */,
 				047691592464026400D73D8B /* SectionHeader.swift in Sources */,
 				0AF5C66D27BAA74300BFEA52 /* WebConnectionTableViewCell.swift in Sources */,
+				0AADCDBE2858CD3800A0139B /* AddOwnerRequestUrlValidator.swift in Sources */,
 				0455A44527282EAA008B772D /* FileManagerWrapper.swift in Sources */,
 				04273E6026D43F0400A14E95 /* IdenticonView.swift in Sources */,
 				555312EF2506641D0008206B /* RIPEMD160.swift in Sources */,
@@ -4780,6 +4787,7 @@
 				0A0EFC9F246EADC200D3D8BF /* DisplayURLTests.swift in Sources */,
 				0A9BC3482460539F00EB9C5D /* ContractTests.swift in Sources */,
 				555312F2250673AD0008206B /* BIP39Tests.swift in Sources */,
+				0AADCDC02858CE2600A0139B /* AddOwnerRequestValidatorTests.swift in Sources */,
 				0AF78A3027E0AAD3001BAFE0 /* WCAppRegistryEntryTests.swift in Sources */,
 				D86A68DF274E692500D7F5C5 /* TestingAppDelegate.swift in Sources */,
 				5532D4CA2449A1980067505A /* CrashlyticsLoggerTests.swift in Sources */,

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -384,6 +384,8 @@ extension MainTabBarViewController: NavigationRouter {
             return true
         } else if route.path == NavigationRoute.deploymentFailedPath {
             return true
+        } else if route.path == NavigationRoute.requestToAddOwnerPath {
+            return true
         }
 
         return false
@@ -413,6 +415,15 @@ extension MainTabBarViewController: NavigationRouter {
             switchTo(indexPath: Path.balances)
         } else if route.path == NavigationRoute.deploymentFailedPath {
             presentFailedDeployment(safe: route.info["safe"] as! Safe)
+        } else if route.path == NavigationRoute.requestToAddOwnerPath {
+            // TODO: Open the add owner flow.
+            let _ = route.info["parameters"] as! AddOwnerRequestParameters
+
+            let vc = InactiveLinkViewController { [weak self] in
+                self?.dismiss(animated: true)
+            }
+            let nav = ViewControllerFactory.modal(viewController: vc)
+            presentWhenReady(nav)
         }
     }
 

--- a/Multisig/UI/App/NavigationRouter.swift
+++ b/Multisig/UI/App/NavigationRouter.swift
@@ -68,4 +68,12 @@ extension NavigationRoute {
         route.info["safe"] = safe
         return route
     }
+
+    static let requestToAddOwnerPath = "/addOwner"
+
+    static func requestToAddOwner(_ params: AddOwnerRequestParameters) -> NavigationRoute {
+        var route = NavigationRoute(path: requestToAddOwnerPath)
+        route.info["parameters"] = params
+        return route
+    }
 }

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddOwnerRequestUrlValidator.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddOwnerRequestUrlValidator.swift
@@ -1,0 +1,53 @@
+//
+//  AddOwnerRequestUrlValidator.swift
+//  Multisig
+//
+//  Created by Dmitry Bespalov on 14.06.22.
+//  Copyright © 2022 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+
+struct AddOwnerRequestParameters {
+    var chain: Chain
+    var safeAddress: Address
+    var ownerAddress: Address
+}
+
+struct AddOwnerRequestValidator {
+    private static let pattern = "^https://gnosis-safe.io/app/([-a-zA-Z0-9]{1,20}):(0x[a-fA-F0-9]{40})/addOwner\\?address=(0x[a-fA-F0-9]{40})$"
+
+    static func isValid(url: URL) -> Bool {
+        guard url.absoluteString.matches(pattern: pattern) else { return false }
+
+        let matches = url.absoluteString.capturedValues(pattern: pattern).flatMap { $0 }
+
+        guard
+            matches.count == 3 &&
+            // safe address at position 1
+            Address(matches[1]) != nil &&
+            // owner address at position 2
+            Address(matches[2]) != nil
+        else {
+            return false
+        }
+        return true
+    }
+
+    static func parameters(from url: URL) -> AddOwnerRequestParameters? {
+        let matches = url.absoluteString.capturedValues(pattern: pattern).flatMap { $0 }
+        guard
+            matches.count == 3,
+            let chain = Chain.by(shortName: matches[0]),
+            let safe = Address(matches[1]),
+            let owner = Address(matches[2])
+        else {
+            return nil
+        }
+        return AddOwnerRequestParameters(
+            chain: chain,
+            safeAddress: safe,
+            ownerAddress: owner
+        )
+    }
+}

--- a/Multisig/UI/WalletConnect/Server/WalletConnectServerController.swift
+++ b/Multisig/UI/WalletConnect/Server/WalletConnectServerController.swift
@@ -29,6 +29,10 @@ class WalletConnectServerController: ServerDelegate {
         server = Server(delegate: self)        
     }
 
+    func canConnect(url: String) -> Bool {
+        WCURL(url) != nil
+    }
+
     func connect(url: String) throws {
         guard let wcurl = WCURL(url) else { throw GSError.InvalidWalletConnectQRCode() }
         do {

--- a/MultisigTests/Logic/AddOwnerRequestValidatorTests.swift
+++ b/MultisigTests/Logic/AddOwnerRequestValidatorTests.swift
@@ -1,0 +1,79 @@
+//
+//  AddOwnerRequestValidatorTests.swift
+//  MultisigTests
+//
+//  Created by Dmitry Bespalov on 14.06.22.
+//  Copyright © 2022 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+class AddOwnerRequestValidatorTests: XCTestCase {
+
+    func testAddOwnerRequestUrls() {
+        assertInvalid("https://gnosis-safe.io", "missing path and query")
+        assertInvalid("ftp://url?query=https://gnosis-safe.io/", "must start with the correct link")
+        assertInvalid("https://gnosis-safe.io/app/", "missing rest of the path and query")
+        assertInvalid("https://gnosis-safe.io/app/something/addOwner?address=else", "wrong format of path and query parameters")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner", "missing owner address query parameter")
+
+        // shortname with dash
+        assertValid("https://gnosis-safe.io/app/eth-weth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "must support dash in shortname")
+
+        // shortname empty, 1, 20, 21
+        assertValid("https://gnosis-safe.io/app/a:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "must support one-char shortname")
+        assertValid("https://gnosis-safe.io/app/abcde12345abcde12345:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "must support 20-char shortname")
+        assertInvalid("https://gnosis-safe.io/app/abcde12345abcde12345e:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "shortname too long")
+        assertInvalid("https://gnosis-safe.io/app/:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "shortname empty")
+
+        // safe address: empty, 39, 40, 41, hex, checksum wrong
+        assertInvalid("https://gnosis-safe.io/app/eth:/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "safe address empty")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "safe address too short")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A1/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "safe address too long")
+        assertValid("https://gnosis-safe.io/app/eth:0x71592e6cbe7779d480c1d029e70904041f8f602a/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "must support hex safe address")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041f8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "must detect wrong checksum in safe address")
+
+        // owner address: empty, 39, 40, 41, hex, checksum wrong
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=", "owner address empty")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b6", "owner address too short")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66a", "owner address too long")
+        assertValid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6a5adb2b88257a3dac7a76a7b4ecacda090b66", "must support hex owner address")
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090B66", "must detect wrong checksum in owner address")
+
+        // additional params
+        assertInvalid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66&some=value", "happy case not working")
+
+
+        // happy case
+        assertValid("https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66", "happy case not working")
+    }
+
+    func testExtractsParameters() {
+        let url = URL(string: "https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66")!
+        guard let parameters = AddOwnerRequestValidator.parameters(from: url) else {
+            XCTFail("Parameters not found in correct link")
+            return
+        }
+
+        XCTAssertEqual(parameters.chain.shortName, "eth")
+        XCTAssertEqual(parameters.safeAddress, "0x71592E6Cbe7779D480C1D029e70904041F8f602A")
+        XCTAssertEqual(parameters.ownerAddress, "0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66")
+    }
+
+    func assertInvalid(_ str: String, _ message: String, line: UInt = #line) {
+        guard let url = URL(string: str) else {
+            XCTFail("Not a url", line: line)
+            return
+        }
+        XCTAssertFalse(AddOwnerRequestValidator.isValid(url: url), message, line: line)
+    }
+
+    func assertValid(_ str: String, _ message: String, line: UInt = #line) {
+        guard let url = URL(string: str) else {
+            XCTFail("Not a url", line: line)
+            return
+        }
+        XCTAssertTrue(AddOwnerRequestValidator.isValid(url: url), message, line: line)
+    }
+}


### PR DESCRIPTION
Handles #2347 

Changes proposed in this pull request:
- Validation of the URL and parameters
- Currently opens a placeholder screen.


To test, in the simulator, add the link to the notes or reminders and then click on it

Example:
https://gnosis-safe.io/app/eth:0x71592E6Cbe7779D480C1D029e70904041F8f602A/addOwner?address=0x8e6A5aDb2B88257A3DAc7A76A7B4EcaCdA090b66
