### PR TITLE
gh-2412 Adjust button position for onboarding screen

### DIFF
--- a/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
+++ b/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
@@ -89,8 +89,6 @@ struct LaunchView: View {
         .onAppear {
             Tracker.trackEvent(.launch)
         }
-
-
     }
 }
 

--- a/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
+++ b/Multisig/UI/SwiftUI/Onboarding/LaunchView.swift
@@ -46,13 +46,14 @@ struct LaunchView: View {
 
     var body: some View {
         GeometryReader { geometryProxy in
+
             ZStack(alignment: .centerAlignment) {
+
                 Image("ico-splash-gradient")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 274, height: 286)
                     .position(x: geometryProxy.size.width - 137, y: geometryProxy.size.height - 143)
-
 
                 VStack(alignment: .center, spacing: 0) {
                     // 100 x 153 px, so no additional framing is required
@@ -63,17 +64,18 @@ struct LaunchView: View {
                     Image("ico-splash-text")
                         .alignmentGuide(.centerVerticalAlignment) { $0[VerticalAlignment.center] }
                         .padding(.bottom, self.textToButtonSpacing)
-
-                    Button("Get Started") {
-                        self.showTerms = true
-                        // overlay view is loaded immediately
-                        // so we can not track on view appear
-                        Tracker.trackEvent(.launchTerms)
-                    }
-                        .buttonStyle(GNOFilledWhiteButtonStyle())
                 }
-            }
 
+                Button("Get Started") {
+                    self.showTerms = true
+                    // overlay view is loaded immediately
+                    // so we can not track on view appear
+                    Tracker.trackEvent(.launchTerms)
+                }
+                .buttonStyle(GNOFilledWhiteButtonStyle())
+                .position(x: geometryProxy.size.width / 2 - 16, y: geometryProxy.size.height - 72)
+
+            }
             .padding(.horizontal)
         }
         .navigationBarHidden(true)
@@ -87,6 +89,8 @@ struct LaunchView: View {
         .onAppear {
             Tracker.trackEvent(.launch)
         }
+
+
     }
 }
 


### PR DESCRIPTION
Handles #2412

Changes proposed in this pull request:
<table>
<tr>
<td>
before
</td>
<td>
after
</td>
</tr>
<tr>
<td>
<image src="https://images.zenhubusercontent.com/5ed757c29459bb36bacd4bba/479e8708-4ca6-43e3-b346-4ccaff6e78ef" width=400/>
</td>
<td>
<image src="https://user-images.githubusercontent.com/17750984/174548501-b4bfda83-f03c-4078-a26f-f582b901aee5.png" width=400/>
</td>
</tr>
</table>
