### PR TITLE
GH-2398 - Adding-missing-EIP-3770-prefixes 

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewAddOwnerTxViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewAddOwnerTxViewController.swift
@@ -75,7 +75,7 @@ class ReviewAddOwnerTxViewController: ReviewSafeTransactionViewController {
                                                     info: nil,
                                                     chainId: safe.chain!.id!)
 
-        cell.set(owner: AddressInfo(address: owner, name: name), action: .addingOwner, prefix: safe.chain!.shortName)
+        cell.set(owner: AddressInfo(address: owner, name: name), action: .addingOwner, prefix: safe.chain?.shortName)
 
         return cell
     }

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewAddOwnerTxViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewAddOwnerTxViewController.swift
@@ -75,7 +75,7 @@ class ReviewAddOwnerTxViewController: ReviewSafeTransactionViewController {
                                                     info: nil,
                                                     chainId: safe.chain!.id!)
 
-        cell.set(owner: AddressInfo(address: owner, name: name), action: .addingOwner)
+        cell.set(owner: AddressInfo(address: owner, name: name), action: .addingOwner, prefix: safe.chain!.shortName)
 
         return cell
     }

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewRemoveOwnerViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewRemoveOwnerViewController.swift
@@ -77,7 +77,7 @@ class ReviewRemoveOwnerViewController: ReviewSafeTransactionViewController {
                                                     info: nil,
                                                     chainId: safe.chain!.id!)
 
-        cell.set(owner: AddressInfo(address: owner, name: name), action: .removingOwner)
+        cell.set(owner: AddressInfo(address: owner, name: name), action: .removingOwner, prefix: safe.chain?.shortName)
 
         return cell
     }

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewReplaceOwnerTxViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/ReviewReplaceOwnerTxViewController.swift
@@ -90,7 +90,8 @@ class ReviewReplaceOwnerTxViewController: ReviewSafeTransactionViewController {
 
             cell.set(
                 newOwner: AddressInfo(address: owner, name: newOwnerName),
-                oldOwner: AddressInfo(address: ownerToBeReplaced, name: oldOwnerName)
+                oldOwner: AddressInfo(address: ownerToBeReplaced, name: oldOwnerName),
+                prefix: safe.chain?.shortName
             )
         
             return cell

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKey/EnterOwnerAddressViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKey/EnterOwnerAddressViewController.swift
@@ -66,7 +66,7 @@ class EnterOwnerAddressViewController: UIViewController {
                 info: nil,
                 chainId: self.safe.chain!.id!)
 
-            self.addressField.setAddress(address, label: resolvedName)
+            self.addressField.setAddress(address, label: resolvedName, prefix: self.safe.chain!.shortName)
             self.name = resolvedName
 
             self.checkEqualToSafe()

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKey/EnterOwnerAddressViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKey/EnterOwnerAddressViewController.swift
@@ -66,7 +66,7 @@ class EnterOwnerAddressViewController: UIViewController {
                 info: nil,
                 chainId: self.safe.chain!.id!)
 
-            self.addressField.setAddress(address, label: resolvedName, prefix: self.safe.chain!.shortName)
+            self.addressField.setAddress(address, label: resolvedName, prefix: self.safe.chain?.shortName)
             self.name = resolvedName
 
             self.checkEqualToSafe()

--- a/Multisig/UI/UI Library/Views/OwnerActionView.swift
+++ b/Multisig/UI/UI Library/Views/OwnerActionView.swift
@@ -15,6 +15,7 @@ class OwnerActionView: UINibView {
     @IBOutlet weak var addressLabel: UILabel!
     @IBOutlet weak var actionTag: TagView!
 
+    private var networkPrefix: String? = nil
 
     override func commonInit() {
         super.commonInit()
@@ -22,10 +23,12 @@ class OwnerActionView: UINibView {
         addressLabel.setStyle(.tertiary)
     }
 
-    func set(owner: AddressInfo, action: OwnerAction) {
+    func set(owner: AddressInfo, action: OwnerAction, prefix: String? = nil) {
         blockie.set(address: owner.address)
         nameLabel.text = owner.name
-        addressLabel.text = owner.address.ellipsized()
+        networkPrefix = prefix
+        addressLabel.text = prependingPrefixString() + owner.address.ellipsized()
+
         switch action {
         case .addingOwner:
             actionTag.set(title: "Adding owner", style: .footnote2, backgroundColor: .backgroundPositive, textColor: .primary)
@@ -34,6 +37,14 @@ class OwnerActionView: UINibView {
         case .removingOwner:
             actionTag.set(title: "Removing owner", style: .footnote2, backgroundColor: .backgroundError, textColor: .error)
         }
+    }
+
+    private func prependingPrefixString() -> String {
+        AppSettings.prependingChainPrefixToAddresses ? prefixString() : ""
+    }
+
+    private func prefixString() -> String {
+        networkPrefix != nil ? "\(networkPrefix!):" : ""
     }
 }
 

--- a/Multisig/UI/UI Library/Views/TableViewCell/ReviewTransactionCells/AddRemoveOwnerTableViewCell.swift
+++ b/Multisig/UI/UI Library/Views/TableViewCell/ReviewTransactionCells/AddRemoveOwnerTableViewCell.swift
@@ -12,7 +12,7 @@ class AddRemoveOwnerTableViewCell: UITableViewCell {
 
     @IBOutlet weak var ownerActionView: OwnerActionView!
 
-    func set(owner: AddressInfo, action: OwnerAction) {
-        ownerActionView.set(owner: owner, action: action)
+    func set(owner: AddressInfo, action: OwnerAction, prefix: String? = nil) {
+        ownerActionView.set(owner: owner, action: action, prefix: prefix)
     }
 }

--- a/Multisig/UI/UI Library/Views/TableViewCell/ReviewTransactionCells/ReplaceOwnerTableViewCell.swift
+++ b/Multisig/UI/UI Library/Views/TableViewCell/ReviewTransactionCells/ReplaceOwnerTableViewCell.swift
@@ -17,8 +17,8 @@ class ReplaceOwnerTableViewCell: UITableViewCell {
         super.awakeFromNib()
     }
 
-    func set(newOwner: AddressInfo, oldOwner: AddressInfo) {
-        newOwnerView.set(owner: newOwner, action: .addingOwner)
-        oldOwnerView.set(owner: oldOwner, action: .replacingOwner)
+    func set(newOwner: AddressInfo, oldOwner: AddressInfo, prefix: String? = nil) {
+        newOwnerView.set(owner: newOwner, action: .addingOwner, prefix: prefix)
+        oldOwnerView.set(owner: oldOwner, action: .replacingOwner, prefix: prefix)
     }
 }


### PR DESCRIPTION
Handles #2398 

Changes proposed in this pull request:
- Add missing EIP-3770 prefixes to added and removed owner addresses

Add / remove | Add | Remove
------------- | ---- | --------
<img width="354" alt="image" src="https://user-images.githubusercontent.com/246473/177528856-87332a98-9c9d-4009-b4b8-8d47e513e404.png"> | <img width="356" alt="image" src="https://user-images.githubusercontent.com/246473/177528971-9cae5154-8451-496b-8f5e-66cd8370815b.png"> | <img width="349" alt="image" src="https://user-images.githubusercontent.com/246473/177532798-f949d9a6-1236-41d3-96be-16c661415eec.png">


