### PR TITLE
gh-2559 - New value for SAFE_DAO_URL in Config

### DIFF
--- a/Multisig/Cross-layer/Configuration/Config.Example.xcconfig
+++ b/Multisig/Cross-layer/Configuration/Config.Example.xcconfig
@@ -120,7 +120,7 @@ FEATURE_SUGGESTION_URL  = https:/$()/safe.cnflx.io/
 CONTACT_EMAIL           = safe@gnosis.io
 FORUM_URL               = https:/$()/forum.gnosis-safe.io/
 //TODO: adjust safe dao url
-SAFE_DAO_URL            = https://snapshot.org/#/safe.eth
+SAFE_DAO_URL            = https:/$()/snapshot.org/#/safe.eth
 
 // Web app url
 GNOSIS_SAFE_WEB_URL_PROD     = https:/$()/gnosis-safe.io/app/

--- a/Multisig/Cross-layer/Configuration/Config.Example.xcconfig
+++ b/Multisig/Cross-layer/Configuration/Config.Example.xcconfig
@@ -120,7 +120,7 @@ FEATURE_SUGGESTION_URL  = https:/$()/safe.cnflx.io/
 CONTACT_EMAIL           = safe@gnosis.io
 FORUM_URL               = https:/$()/forum.gnosis-safe.io/
 //TODO: adjust safe dao url
-SAFE_DAO_URL            = https:/$()/gnosis-safe.io/
+SAFE_DAO_URL            = https://snapshot.org/#/safe.eth
 
 // Web app url
 GNOSIS_SAFE_WEB_URL_PROD     = https:/$()/gnosis-safe.io/app/


### PR DESCRIPTION
Handles #2559

Changes proposed in this pull request:
- Update SAFE_DAO_URL to https:/$()/snapshot.org/#/safe.eth in Config.example.xcconfig

