### PR TITLE
Fix object referencing

### DIFF
--- a/Multisig/UI/UI Library/KeyboardAvoidingBehavior.swift
+++ b/Multisig/UI/UI Library/KeyboardAvoidingBehavior.swift
@@ -146,8 +146,8 @@ class KeyboardAvoidingBehavior {
             scrollView.contentInset.bottom = 0
             scrollView.scrollIndicatorInsets = scrollView.contentInset
         }
-        DispatchQueue.main.async { [unowned self] in
-            willHideKeyboard(duration.doubleValue)
+        DispatchQueue.main.async { [weak self] in
+            self?.willHideKeyboard(duration.doubleValue)
         }
     }
 


### PR DESCRIPTION
Handles #2653 

Changes proposed in this pull request:
- With the old implementation with have the following fatal error being thrown when calling willHideKeyboard closure 
![Screen Shot 2022-09-09 at 12 58 36 PM](https://user-images.githubusercontent.com/58591867/189335427-d43384e1-5cce-4a51-aa9f-6b3d97523b15.png)
