### PR TITLE
[Keystone] Change transaction type for legacy, remove the error dialog when user cancel the operation

### DIFF
--- a/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
@@ -426,12 +426,13 @@ class SendTransactionRequestViewController: WebConnectionContainerViewController
             
         case .keystone:
             let gsError = GSError.error(description: "Signing failed")
+            let isLegacy = transaction is Eth.TransactionLegacy
             
             let signInfo = KeystoneSignInfo(
                 signData: transaction.preImageForSigning().toHexString(),
                 chain: chain,
                 keyInfo: keyInfo,
-                signType: .typedTransaction
+                signType: isLegacy ? .transaction : .typedTransaction
             )
             let signCompletion = { [unowned self] (success: Bool) in
                 keystoneSignFlow = nil

--- a/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Send Transaction Request/SendTransactionRequestViewController.swift
@@ -434,11 +434,8 @@ class SendTransactionRequestViewController: WebConnectionContainerViewController
                 keyInfo: keyInfo,
                 signType: isLegacy ? .transaction : .typedTransaction
             )
-            let signCompletion = { [unowned self] (success: Bool) in
+            let signCompletion = { [unowned self] (_: Bool) in
                 keystoneSignFlow = nil
-                if !success {
-                    App.shared.snackbar.show(error: gsError)
-                }
             }
             guard let signFlow = KeystoneSignFlow(signInfo: signInfo, completion: signCompletion) else {
                 App.shared.snackbar.show(error: gsError)

--- a/Multisig/Features/Connect to Web/UI/Signature Request/SignatureRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Signature Request/SignatureRequestViewController.swift
@@ -232,11 +232,8 @@ class SignatureRequestViewController: WebConnectionContainerViewController, WebC
                 keyInfo: keyInfo,
                 signType: .personalMessage
             )
-            let signCompletion = { [unowned self] (success: Bool) in
+            let signCompletion = { [unowned self] (_: Bool) in
                 keystoneSignFlow = nil
-                if !success {
-                    App.shared.snackbar.show(error: gsError)
-                }
             }
             guard let signFlow = KeystoneSignFlow(signInfo: signInfo, completion: signCompletion) else {
                 App.shared.snackbar.show(error: gsError)

--- a/Multisig/Logic/Keystone/KeystoneSignInfo.swift
+++ b/Multisig/Logic/Keystone/KeystoneSignInfo.swift
@@ -10,8 +10,9 @@ import Foundation
 import URRegistry
 
 struct KeystoneSignInfo {
-    enum KeystoneSignType: Int {
-        case personalMessage = 3
+    enum KeystoneSignType {
+        case transaction
+        case personalMessage
         case typedTransaction
     }
     
@@ -29,14 +30,21 @@ extension KeystoneSignInfo {
             let chainIdNumber = UInt32(chainId),
             let metadata = keyInfo.metadata,
             let keyMetadata = KeyInfo.KeystoneKeyMetadata.from(data: metadata),
-            let signType = KeystoneSignRequest.SignType(rawValue: signType.rawValue),
             keyInfo.keyType == .keystone
         else { return nil }
+        
+        let signRequestType: KeystoneSignRequest.SignType = {
+            switch signType {
+            case .transaction: return .transaction
+            case .personalMessage: return .personalMessage
+            case .typedTransaction: return .typedTransaction
+            }
+        }()
         
         return KeystoneSignRequest(
             requestId: requestId,
             signData: signData,
-            signType: signType,
+            signType: signRequestType,
             chainId: chainIdNumber,
             path: keyMetadata.path,
             xfp: keyMetadata.sourceFingerprint,

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -779,11 +779,8 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
                 keyInfo: keyInfo,
                 signType: isLegacy ? .transaction : .typedTransaction
             )
-            let signCompletion = { [unowned self] (success: Bool) in
+            let signCompletion = { [unowned self] (_: Bool) in
                 keystoneSignFlow = nil
-                if !success {
-                    App.shared.snackbar.show(error: gsError)
-                }
             }
             guard let signFlow = KeystoneSignFlow(signInfo: signInfo, completion: signCompletion) else {
                 App.shared.snackbar.show(error: gsError)

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -771,12 +771,13 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
 
         case .keystone:
             let gsError = GSError.error(description: "Signing failed")
+            let isLegacy = uiModel.transaction is Eth.TransactionLegacy
             
             let signInfo = KeystoneSignInfo(
                 signData: uiModel.transaction.preImageForSigning().toHexString(),
                 chain: chain,
                 keyInfo: keyInfo,
-                signType: .typedTransaction
+                signType: isLegacy ? .transaction : .typedTransaction
             )
             let signCompletion = { [unowned self] (success: Bool) in
                 keystoneSignFlow = nil

--- a/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionViewController.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionViewController.swift
@@ -517,11 +517,8 @@ class ReviewExecutionViewController: ContainerViewController, PasscodeProtecting
                 keyInfo: keyInfo,
                 signType: isLegacy ? .transaction : .typedTransaction
             )
-            let signCompletion = { [unowned self] (success: Bool) in
+            let signCompletion = { [unowned self] (_: Bool) in
                 keystoneSignFlow = nil
-                if !success {
-                    App.shared.snackbar.show(error: gsError)
-                }
             }
             guard let signFlow = KeystoneSignFlow(signInfo: signInfo, completion: signCompletion) else {
                 App.shared.snackbar.show(error: gsError)

--- a/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionViewController.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionViewController.swift
@@ -509,12 +509,13 @@ class ReviewExecutionViewController: ContainerViewController, PasscodeProtecting
             
         case .keystone:
             let gsError = GSError.error(description: "Signing failed")
+            let isLegacy = controller.isLegacyTx
             
             let signInfo = KeystoneSignInfo(
                 signData: controller.preimageForSigning().toHexString(),
                 chain: chain,
                 keyInfo: keyInfo,
-                signType: .typedTransaction
+                signType: isLegacy ? .transaction : .typedTransaction
             )
             let signCompletion = { [unowned self] (success: Bool) in
                 keystoneSignFlow = nil

--- a/Multisig/UI/Transaction/InitiateTransaction/ReviewSafeTransactionViewController/ReviewSafeTransactionViewController.swift
+++ b/Multisig/UI/Transaction/InitiateTransaction/ReviewSafeTransactionViewController/ReviewSafeTransactionViewController.swift
@@ -291,7 +291,6 @@ class ReviewSafeTransactionViewController: UIViewController {
             let signCompletion = { [unowned self] (success: Bool) in
                 keystoneSignFlow = nil
                 if !success {
-                    App.shared.snackbar.show(error: gsError)
                     endConfirm()
                 }
             }

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
@@ -139,7 +139,6 @@ class RejectionConfirmationViewController: UIViewController {
             let signCompletion = { [unowned self] (success: Bool) in
                 keystoneSignFlow = nil
                 if !success {
-                    App.shared.snackbar.show(error: gsError)
                     endLoading()
                 }
             }

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
@@ -393,11 +393,8 @@ class TransactionDetailsViewController: LoadableViewController, UITableViewDataS
                 keyInfo: keyInfo,
                 signType: .personalMessage
             )
-            let signCompletion = { [unowned self] (success: Bool) in
+            let signCompletion = { [unowned self] (_: Bool) in
                 keystoneSignFlow = nil
-                if !success {
-                    onError(gsError)
-                }
             }
             guard let signFlow = KeystoneSignFlow(signInfo: signInfo, completion: signCompletion) else {
                 onError(gsError)


### PR DESCRIPTION
There are two purposes in this PR:

- Change sign type for legacy transaction
- If the user cancel the operation, we do not need to show an error dialog to user