### PR TITLE
gh-2715 Remove ssl pin for gnosis.io

### DIFF
--- a/Multisig/Info.plist
+++ b/Multisig/Info.plist
@@ -173,20 +173,6 @@
 	<dict>
 		<key>TSKPinnedDomains</key>
 		<dict>
-			<key>gnosis.io</key>
-			<dict>
-				<key>TSKDisableDefaultReportUri</key>
-				<true/>
-				<key>TSKEnforcePinning</key>
-				<string>$(SSL_ENFORCE_PINNING)</string>
-				<key>TSKIncludeSubdomains</key>
-				<true/>
-				<key>TSKPublicKeyHashes</key>
-				<array>
-					<string>JSMzqOOrtyOT1kmau6zKhgT676hGgczD5VMdRMyJZFA=</string>
-					<string>++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</string>
-				</array>
-			</dict>
 			<key>5afe.dev</key>
 			<dict>
 				<key>TSKDisableDefaultReportUri</key>


### PR DESCRIPTION
Handles #2715

Changes proposed in this pull request:
- Remove obsolete ssl pin

