### PR TITLE
Gh 2828/app lock unlock

### DIFF
--- a/Multisig/Features/Security/EncryptedStore.swift
+++ b/Multisig/Features/Security/EncryptedStore.swift
@@ -10,21 +10,17 @@ import Foundation
 import CommonCrypto
 import CryptoKit
 
-typealias EthPrivateKey = Data
-
 protocol EncryptedStore {
     func isInitialized() -> Bool
     func initializeKeyStore() throws
-    func `import`(id: DataID, ethPrivateKey: EthPrivateKey) throws
-    func `import`(id: DataID, plainText: Data)  throws
-    func delete(address: Address) throws
+    func `import`(id: DataID, data: Data) throws
     func delete(id: DataID) throws
 
     /// Find private signer key.
     /// - parameter address: find key for this address
     /// - parameter password: application password. Can be nil, then the stored password is used
     /// - returns: String with hex encoded bytes of the private key or nil if key not found
-    func find(dataID: DataID, password: String?) throws -> EthPrivateKey?
+    func find(dataID: DataID, password: String?) throws -> Data?
     func changePassword(from oldPassword: String?, to newPassword: String?, useBiometry: Bool) throws
 
     func deleteAllKeys() throws

--- a/Multisig/Features/Security/KeychainStore.swift
+++ b/Multisig/Features/Security/KeychainStore.swift
@@ -19,6 +19,7 @@ class KeychainItemStore {
 
     private let store: KeychainStore
 
+    @discardableResult
     func create(_ item: KeychainItem) throws -> Any {
         switch item {
         case .ecKeyPair: break

--- a/Multisig/Features/Security/SecurityCenter.swift
+++ b/Multisig/Features/Security/SecurityCenter.swift
@@ -18,6 +18,7 @@ class SecurityCenter {
 
     private static let version: Int32 = 1
     private static let appUnlockChallengeID = "global.safe.AppUnlockChallenge"
+    private static let challenge = "I am not alive, but I grow; I don't have lungs, but I need air; I don't have a mouth, but water kills me. What am I?"
 
     private var isRequirePasscodeEnabled: Bool {
         AppSettings.securityLockEnabled
@@ -79,6 +80,7 @@ class SecurityCenter {
         }
         if !dataStore.isInitialized() {
             try dataStore.initialize()
+            try dataStore.import(id: DataID(id: Self.appUnlockChallengeID), data: Self.challenge.data(using: .utf8)!)
         }
     }
 
@@ -99,10 +101,10 @@ class SecurityCenter {
     /// Import data potentially overriding existing value
     ///
     /// - Parameters:
-    ///   - id: key data id
-    ///   - ethPrivateKey: private key data
+    ///   - id:  data id
+    ///   - data: data to protect
     ///   - completion: callback returns success(true) if import successfull, success(false) if operation was canceled by user, or failure otherwise.
-    func `import`(id: DataID, ethPrivateKey: EthPrivateKey, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {
+    func `import`(id: DataID, data: Data, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {
         switch(protectionClass) {
         case .sensitive:
             perfomSecuredAccess { [unowned self] result in
@@ -128,10 +130,10 @@ class SecurityCenter {
         }
     }
 
-    /// Remove key from keystore
+    /// Remove data from keystore
     ///
     /// - Parameters:
-    ///   - dataID: key data id
+    ///   - dataID: data id
     ///   - protectionClass: which keystore to use for removal: sensitive or data
     ///   - completion: callback returns success(true) if import successfull, success(false) if operation was canceled by user, or failure otherwise.
     func remove(dataID: DataID, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {

--- a/Multisig/Features/Security/SecurityCenter.swift
+++ b/Multisig/Features/Security/SecurityCenter.swift
@@ -16,12 +16,11 @@ class SecurityCenter {
     private let sensitiveStore: ProtectedKeyStore
     private let dataStore: ProtectedKeyStore
     private static let version: Int32 = 1
-    
-    var securityLockEnabled: Bool {
+
     private static let appUnlockChallengeID = "global.safe.AppUnlockChallenge"
     private static let challenge = "I am not alive, but I grow; I don't have lungs, but I need air; I don't have a mouth, but water kills me. What am I?"
 
-    private var isRequirePasscodeEnabled: Bool {
+    var securityLockEnabled: Bool {
         AppSettings.securityLockEnabled
     }
 
@@ -89,22 +88,127 @@ class SecurityCenter {
             try dataStore.import(id: DataID(id: Self.appUnlockChallengeID), data: Self.challenge.data(using: .utf8)!)
         }
     }
+    // change lock method:
+        // passcode
+            // old pass -> same pass
+            // use biometry = false
+        // userPresence
+            // old pass is nil -> same pass
+            // use biometry = true
+        // passcode & user presence
+            // old pass -> same pass
+            // use biometry = true
 
-    func changeSecuritySettings(passcode: String?, lockMethod: LockMethod? = nil,  completion: @escaping (Error?) -> Void) {
-        let password: String? = passcode == nil ? nil : derivedKey(from: passcode!)
-        let newLockMethod = lockMethod == nil ? self.lockMethod : lockMethod!
-        perfomSecuredAccess { [unowned self] result in
-            let SUCCESS: Error? = nil
+    // change passcode:
+        // use biometry = old use biometry
+        // old pass -> new pass
+
+    // TODO: only ask for passcode in create passcode if user declines face id
+
+    // TODO: user-facing error handling
+
+    // Requires:
+    //  - AppSettings.lockMethod is set
+    //  - passcode not nil if lockMethod is `.passcode` or `.passcodeAndUserPresence`, and nil if lockMethod is `.userPresence`
+    //  - passcode is a plaintext passcode
+    // Guarantees:
+    //  - Sensitive store's encryption keys changed according to new options
+    //  - Data store's encryption keys changed according to new options
+    //     - Data store is only protected with user passcode when the lock method is `.passcode`
+    func enableSecurityLock(passcode: String?) throws {
+        do {
+            AppSettings.passcodeOptions = [.useForLogin, .useForConfirmation]
+
+            try changeStoreSettings(currentPlaintextPassword: nil, newPlaintextPassword: passcode, store: sensitiveStore)
+            try changeStoreSettings(currentPlaintextPassword: nil, newPlaintextPassword: passcode, store: dataStore)
+
+            AppSettings.securityLockEnabled = true
+            AppSettings.passcodeWasSetAtLeastOnce = true
+
+            Tracker.setPasscodeIsSet(to: true)
+            Tracker.trackEvent(.userPasscodeEnabled)
+
+            NotificationCenter.default.post(name: .passcodeCreated, object: nil)
+        } catch {
+            AppSettings.passcodeOptions = []
+            throw error
+        }
+    }
+
+    // TODO: we need to keep the dataStore unlocked when the app is in foreground, i.e. to unlock it once:
+        // when the lock is enabled -> app becomes unlocked
+        // when the app enters foreground and unlocks -> then it's OK.
+
+    fileprivate func changeStoreSettings(currentPlaintextPassword: String?, newPlaintextPassword: String?, store: ProtectedKeyStore) throws {
+        let currentDerivedPassword = currentPlaintextPassword.map { derivedKey(from: $0) }
+        let newDerivedPassword = newPlaintextPassword.map { derivedKey(from: $0) }
+
+        let newStorePassword: String?
+        let biometryUsed: Bool
+
+        let optionForStore: PasscodeOptions = store === sensitiveStore ? .useForConfirmation : .useForLogin
+        let isStoreLockEnabled: Bool = AppSettings.passcodeOptions.contains(optionForStore)
+
+        if isStoreLockEnabled {
+            // sensitive store can ask passcode and biometrics to access the items, depending on the lock method.
+            // data store only asks for passcode if that's the lock method. Otherwise, it uses biometric authentication.
+            let lockMethodsWithPassword: [LockMethod] = store === sensitiveStore ? [.passcode, .passcodeAndUserPresence] : [.passcode]
+            let lockMethodsWithBiometry: [LockMethod] = [.userPresence, .passcodeAndUserPresence]
+
+            newStorePassword = lockMethodsWithPassword.contains(AppSettings.securityLockMethod) ? newDerivedPassword! : nil
+            biometryUsed = lockMethodsWithBiometry.contains(AppSettings.securityLockMethod)
+        } else {
+            newStorePassword = nil
+            biometryUsed = false
+        }
+        try store.changePassword(from: currentDerivedPassword, to: newStorePassword, useBiometry: biometryUsed)
+    }
+
+    // TODO: cancelling is not an error? success = false means cancelled?
+    // Requires:
+    //  - AppSettings.securityLockEnabled is true
+    //  - AppSettings.lockMethod and AppSettings.passcodeOptions are current
+    // Guarantees:
+    //  - If user enters correct passcode & biometrics (when needed), then the passcode and biometrics are disabled.
+    //    AND the completion block is called with 'nil' result
+    //  - If user enters wrong passcode or biometrics OR cancels authentication, then the completion is called with error result.
+    func disableSecurityLock(completion: @escaping (Error?) -> ()) {
+        let oldOptions = AppSettings.passcodeOptions
+
+        requestPasswordV2(for: [.sensitive, .data]) { [unowned self] plaintextPasscode in
+            // disable all locks
+            AppSettings.passcodeOptions = []
+
+            try changeStoreSettings(currentPlaintextPassword: plaintextPasscode, newPlaintextPassword: nil, store: sensitiveStore)
+            try changeStoreSettings(currentPlaintextPassword: plaintextPasscode, newPlaintextPassword: nil, store: dataStore)
+            completion(nil)
+        } onFailure: { error in
+            AppSettings.passcodeOptions = oldOptions
+            completion(error)
+        }
+    }
+
+    private func requestPasswordV2(for accessScope: [ProtectionClass], task: @escaping (_ plaintextPasscode: String?) throws -> Void, onFailure: @escaping (_ error: Error) -> Void) {
+        let needsUserPasscode =
+            AppSettings.securityLockEnabled &&
+            (
+                accessScope.contains(.sensitive) && AppSettings.passcodeOptions.contains(.useForConfirmation) && [LockMethod.passcode, .passcodeAndUserPresence].contains(AppSettings.securityLockMethod) ||
+                accessScope.contains(.data) && AppSettings.passcodeOptions.contains(.useForLogin) && [LockMethod.passcode].contains(AppSettings.securityLockMethod)
+            )
+
+        if needsUserPasscode {
+            NotificationCenter.default.post(name: .passcodeRequired,
+                                            object: self,
+                                            userInfo: ["accessTask": task, "onFailure": onFailure])
+        } else {
             do {
-                let old = try result.get()
-                try sensitiveStore.changePassword(from: old, to: password, useBiometry: newLockMethod != .passcode)
-                try dataStore.changePassword(from: old, to: password, useBiometry: newLockMethod != .passcode)
-                completion(SUCCESS)
+                try task(nil)
             } catch {
-                completion(error)
+                onFailure(error)
             }
         }
     }
+
 
     /// Import data potentially overriding existing value
     ///
@@ -113,28 +217,12 @@ class SecurityCenter {
     ///   - data: data to protect
     ///   - completion: callback returns success(true) if import successfull, success(false) if operation was canceled by user, or failure otherwise.
     func `import`(id: DataID, data: Data, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {
-        switch(protectionClass) {
-        case .sensitive:
-            perfomSecuredAccess { [unowned self] result in
-                switch result {
-                case .success:
-                    do {
-                        try sensitiveStore.import(id: id, data: data)
-                        completion(.success(true))
-                    } catch let error {
-                        completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
-                    }
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            }
-        case .data:
-            do {
-                try dataStore.import(id: id, data: data)
-                completion(.success(true))
-            } catch let error {
-                completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
-            }
+        let store: ProtectedKeyStore = protectionClass == .sensitive ? sensitiveStore : dataStore
+        do {
+            try store.import(id: id, data: data)
+            completion(.success(true))
+        } catch let error {
+            completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
         }
     }
 
@@ -145,76 +233,45 @@ class SecurityCenter {
     ///   - protectionClass: which keystore to use for removal: sensitive or data
     ///   - completion: callback returns success(true) if import successfull, success(false) if operation was canceled by user, or failure otherwise.
     func remove(dataID: DataID, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {
-        switch(protectionClass) {
-        case .sensitive:
-            perfomSecuredAccess { [unowned self] result in
-                switch result {
-                case .success:
-                    do {
-                        try sensitiveStore.delete(id: dataID)
-                        completion(.success(true))
-                    } catch let error {
-                        completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
-                    }
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            }
-        case .data:
-            do {
-                try dataStore.delete(id: dataID)
-                completion(.success(true))
-            } catch let error {
-                completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
-            }
+        let store: ProtectedKeyStore = protectionClass == .sensitive ? sensitiveStore : dataStore
+        do {
+            try store.delete(id: dataID)
+            completion(.success(true))
+        } catch let error {
+            completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
         }
     }
 
-    func find(dataID: DataID, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Data?, Error>) -> ()) {
-        switch(protectionClass) {
-        case .sensitive:
-            perfomSecuredAccess { [unowned self] result in
-                switch result {
-                case .success(let passcode):
-                    do {
-                        let key = try sensitiveStore.find(dataID: dataID, password: passcode)
-                        completion(.success(key))
-                    } catch let error {
-                        completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
-                    }
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            }
-        case .data:
-            do {
-                let key = try dataStore.find(dataID: dataID, password: nil)
-                completion(.success(key))
-            } catch let error {
-                completion(.failure(GSError.KeychainError(reason: error.localizedDescription)))
-            }
+    func find(dataID id: DataID, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Data?, Error>) -> ()) {
+        let store: ProtectedKeyStore = protectionClass == .sensitive ? sensitiveStore : dataStore
+        requestPassword(scope: [protectionClass]) { [unowned self] plaintextPassword in
+            let password = plaintextPassword.map { derivedKey(from: $0) }
+            let data = try store.find(dataID: id, password: password)
+            completion(.success(data))
+        } onFailure: { error in
+            completion(.failure(error))
         }
+
     }
 
-    private func perfomSecuredAccess(completion: @escaping (Result<String?, Error>) -> ()) {
-        guard securityLockEnabled else {
-            completion(.success(nil))
-            return
-        }
-
-        let getPasscodeCompletion: (_ success: Bool, _ reset: Bool, _ passcode: String?) -> () = { success, reset, passcode in
-            // TODO: handle data reset
-            // TODO: handle incorrect passcode
-            if success {
-                completion(.success(passcode.map { App.shared.securityCenter.derivedKey(from: $0) }))
-            } else {
-                completion(.failure(GSError.RequiredPasscode()))
+    // TODO: handle data reset
+    private func requestPassword(scope: Set<ProtectionClass>, task: @escaping (_ password: String?) throws -> Void, onFailure: @escaping (_ error: Error) -> Void) {
+        if
+            securityLockEnabled &&
+            (lockMethod == .passcode || lockMethod == .passcodeAndUserPresence) &&
+                (scope.contains(.sensitive) && AppSettings.passcodeOptions.contains(.useForConfirmation) ||
+                 scope.contains(.data) && AppSettings.passcodeOptions.contains(.useForLogin))
+        {
+            NotificationCenter.default.post(name: .passcodeRequired,
+                                            object: self,
+                                            userInfo: ["accessTask": task, "onFailure": onFailure])
+        } else {
+            do {
+                try task(nil)
+            } catch {
+                onFailure(error)
             }
         }
-
-        NotificationCenter.default.post(name: .passcodeRequired,
-                                        object: self,
-                                        userInfo: ["completion": getPasscodeCompletion])
     }
 
     func derivedKey(from plaintext: String, useOldSalt: Bool = false) -> String {
@@ -242,3 +299,6 @@ class SecurityCenter {
         oldSalt ? "Gnosis Safe Multisig Passcode Salt" : "Safe Multisig Passcode Salt"
     }
 }
+
+// SecCenter -> find -> receive pass -> try store.find() -> completed
+// SecCent -> find -> receive pass -> try store.find() -> error -> try store.find() ->

--- a/Multisig/Logic/Models/AppSettings.swift
+++ b/Multisig/Logic/Models/AppSettings.swift
@@ -89,6 +89,8 @@ extension AppSettings {
 
     // MARK: - Security & Passcode
 
+    // TODO: make a group for security
+
     @AppSetting(\.passcodeBannerDismissed)
     static var passcodeBannerDismissed: Bool
 

--- a/Multisig/Logic/Models/PrivateKey/PrivateKey.swift
+++ b/Multisig/Logic/Models/PrivateKey/PrivateKey.swift
@@ -148,11 +148,7 @@ extension PrivateKey {
     }
 
     static func remove(id: KeyID, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {
-        try Self.remove(id: id, protectionClass: protectionClass, completion: completion)
-    }
-
-    static func remove(address: Address, protectionClass: ProtectionClass = .sensitive, completion: @escaping (Result<Bool, Error>) -> ()) {
-        App.shared.securityCenter.remove(address: address, completion: completion)
+        Self.remove(id: id, protectionClass: protectionClass, completion: completion)
     }
 
     static func deleteAll() throws {
@@ -173,7 +169,7 @@ extension PrivateKey {
         if AppConfiguration.FeatureToggles.securityCenter {
             //TODO: rewrite as App.securityCenter
             //TODO: make invocation async
-            App.shared.securityCenter.import(id: DataID(id: id), ethPrivateKey: keychainData, protectionClass: protectionClass) { result in
+            App.shared.securityCenter.import(id: DataID(id: id), data: keychainData, protectionClass: protectionClass) { result in
                 try! result.get()
             }
         } else {

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -318,22 +318,37 @@ class MainTabBarViewController: UITabBarController {
     }
 
     @objc private func handlePasscodeRequired(_ notification: Notification) {
-        let completion = notification.userInfo?["completion"] as? ((Bool, Bool, String?) -> ())
-        if App.shared.auth.isPasscodeSetAndAvailable {
-            let passcodeVC = EnterPasscodeViewController()
-            passcodeVC.usesBiometry = false
-            passcodeVC.passcodeCompletion = { [weak self] success, reset, passcode in
-                self?.dismiss(animated: true) {
-                    completion?(success, reset, passcode)
-                }
-            }
-
-            let nav = UINavigationController(rootViewController: passcodeVC)
-            nav.modalPresentationStyle = .fullScreen
-            present(nav, animated: true)
-        } else {
-            completion?(true, false, nil)
+        guard
+            let task = notification.userInfo?["accessTask"] as? (_ password: String?) throws -> Void,
+            let onFailure = notification.userInfo?["onFailure"] as? (_ error: Error) -> Void
+        else {
+            return
         }
+
+        let passcodeVC = EnterPasscodeViewController()
+        passcodeVC.usesBiometry = false
+        passcodeVC.onPasscodeEnter = task
+        passcodeVC.onError = onFailure
+        let nav = UINavigationController(rootViewController: passcodeVC)
+        nav.modalPresentationStyle = .fullScreen
+        present(nav, animated: true)
+
+//        let completion = notification.userInfo?["completion"] as? ((Bool, Bool, String?) -> ())
+//        if App.shared.auth.isPasscodeSetAndAvailable {
+//            let passcodeVC = EnterPasscodeViewController()
+//            passcodeVC.usesBiometry = false
+//            passcodeVC.passcodeCompletion = { [weak self] success, reset, passcode in
+//                self?.dismiss(animated: true) {
+//                    completion?(success, reset, passcode)
+//                }
+//            }
+//
+//            let nav = UINavigationController(rootViewController: passcodeVC)
+//            nav.modalPresentationStyle = .fullScreen
+//            present(nav, animated: true)
+//        } else {
+//            completion?(true, false, nil)
+//        }
     }
 
     private func presentSuccessDeployment(safe: Safe) {

--- a/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/Backup/BackupFlow.swift
@@ -87,7 +87,11 @@ class BackupFlow: UIFlow {
 class ModalBackupFlow: BackupFlow {
 
     override func start() {
-        passcode()
+        if AppSettings.securityLockEnabled {
+            seed()
+        } else {
+            passcode()
+        }
     }
 
     func passcode() {

--- a/Multisig/UI/Settings/Passcode/Create Passcode/CreatePasscodeFlow.swift
+++ b/Multisig/UI/Settings/Passcode/Create Passcode/CreatePasscodeFlow.swift
@@ -17,7 +17,7 @@ import UIKit
 /// 1.1. Nothing, if the passcode already created.
 class CreatePasscodeFlow: UIFlow {
     var factory: PasscodeFlowFactory
-    private var userPasscode: String!
+    private var userPasscode: String?
 
     init(factory: PasscodeFlowFactory = PasscodeFlowFactory(), completion: @escaping (_ success: Bool) -> Void) {
         self.factory = factory
@@ -25,8 +25,99 @@ class CreatePasscodeFlow: UIFlow {
     }
 
     override func start() {
-        createPasscode()
+        if AppConfiguration.FeatureToggles.securityCenter {
+            startV2()
+        } else {
+            createPasscode()
+        }
     }
+
+    func startV2() {
+        userPasscode = nil
+
+        if App.shared.securityCenter.securityLockEnabled {
+            stop(success: false)
+            return
+        }
+
+        createPasscodeV2()
+        setupBiometryV2()
+    }
+
+    func setupBiometryV2() {
+        AppSettings.securityLockMethod = .passcode
+
+        // if device does not support biometrics, finish right away
+        guard App.shared.auth.isBiometricsSupported else {
+            createPasscodeV2()
+            return
+        }
+
+        //   if device supports it, ask if to enable biometry
+        let biometryAlert = factory.enableBiometryAlert { [unowned self] in
+
+            // if user enabled biometry, we finish
+            if AppSettings.securityLockMethod == .userPresence {
+                stop(success: true)
+            }
+
+            // otherwise, alert is dismissed to show the passcode screen.
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) { [unowned self] in
+            self.navigationController.present(biometryAlert, animated: true)
+        }
+    }
+
+    func createPasscodeV2() {
+        let createVC = factory.create()
+        createVC.completion = { [unowned self, unowned createVC] in
+
+            // if entered no passcode, then we finish with failure
+            guard let passcode = createVC.passcode else {
+                stop(success: false)
+                return
+            }
+
+            // reset the value to remove from memory
+            createVC.passcode = nil
+
+            // if entered passcode, we ask to repeat it
+            repeatPasscodeV2(passcode: passcode)
+        }
+        createVC.skipCompletion = { [unowned self] in
+
+            // if skipped to enter the passcode, then we finish with failure
+            stop(success: false)
+        }
+
+        show(createVC)
+    }
+
+    // if v2 failed / skipped, the options & lock method needs to be reset
+
+    func repeatPasscodeV2(passcode: String) {
+        let repeatVC = factory.repeatPasscode(passcode)
+        repeatVC.completion = { [unowned self, unowned repeatVC] in
+            // repeated passcode was matching entered passcode, so we finish with success.
+            userPasscode = repeatVC.passcode
+
+            // reset from memory
+            repeatVC.passcode = nil
+
+            stop(success: true)
+        }
+        repeatVC.skipCompletion = { [unowned self] in
+            // passcode repeat was skipped, so we finish with failure
+
+            // reset passcode from memory
+            repeatVC.passcode = nil
+
+            stop(success: false)
+        }
+        show(repeatVC)
+    }
+
 
     func createPasscode() {
         guard !App.shared.auth.isPasscodeSetAndAvailable else {
@@ -86,17 +177,34 @@ class CreatePasscodeFlow: UIFlow {
         defer {
             userPasscode = nil
         }
-        if success {
-            do {
-                try App.shared.auth.createPasscode(plaintextPasscode: userPasscode)
-                App.shared.snackbar.show(message: "Passcode created")
-                super.stop(success: true)
-                return
-            } catch {
-                App.shared.snackbar.show(message: "Failed to create passcode")
+        if AppConfiguration.FeatureToggles.securityCenter {
+            if success {
+                // we have successfully received input from user: biometry or passcode.
+                // we have set the lock method already
+                do {
+                    try App.shared.securityCenter.enableSecurityLock(passcode: userPasscode)
+                    App.shared.snackbar.show(message: "Passcode created")
+                    super.stop(success: true)
+                } catch {
+                    App.shared.snackbar.show(message: "Failed to create passcode")
+                    super.stop(success: false)
+                }
+            } else {
+                super.stop(success: false)
             }
+        } else {
+            if success {
+                do {
+                    try App.shared.auth.createPasscode(plaintextPasscode: userPasscode!)
+                    App.shared.snackbar.show(message: "Passcode created")
+                    super.stop(success: true)
+                    return
+                } catch {
+                    App.shared.snackbar.show(message: "Failed to create passcode")
+                }
+            }
+            super.stop(success: false)
         }
-        super.stop(success: false)
     }
 }
 

--- a/Multisig/UI/Settings/Passcode/SecuritySettingsViewController.swift
+++ b/Multisig/UI/Settings/Passcode/SecuritySettingsViewController.swift
@@ -217,14 +217,15 @@ class SecuritySettingsViewController: UITableViewController {
 
     private func toggleBiometricsSecurityLock(newLockMethod: LockMethod) {
         guard newLockMethod != App.shared.securityCenter.lockMethod else { return }
-        App.shared.securityCenter.changeSecuritySettings(passcode: nil,
-                                                         lockMethod: newLockMethod) { [unowned self] error in
-            if let error = error {
-                LogService.shared.error("Failed to update lock method", error: error)
-            }
-
-            reloadData()
-        }
+        // TODO: biometrics changed!
+//        App.shared.securityCenter.changeSecuritySettings(newPlaintextPasscode: nil,
+//                                                         lockMethod: newLockMethod) { [unowned self] error in
+//            if let error = error {
+//                LogService.shared.error("Failed to update lock method", error: error)
+//            }
+//
+//            reloadData()
+//        }
     }
 
     private func hasFailedBecauseBiometryNotEnabled(_ result: Result<Void, Error>) -> Bool {

--- a/MultisigTests/Features/Security/ProtectedKeyStoreTests.swift
+++ b/MultisigTests/Features/Security/ProtectedKeyStoreTests.swift
@@ -36,7 +36,7 @@ public class ProtectedKeyStoreTests: XCTestCase {
     }
 
     func testImport() throws {
-        let randomKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as EthPrivateKey
+        let randomKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as Data
         try sensitiveKeyStore.initializeKeyStore()
 
         try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey)
@@ -46,8 +46,8 @@ public class ProtectedKeyStoreTests: XCTestCase {
     }
 
     func testImportOverride() throws {
-        let randomKey1 = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as EthPrivateKey
-        let randomKey2 = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c323") as EthPrivateKey
+        let randomKey1 = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as Data
+        let randomKey2 = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c323") as Data
         try sensitiveKeyStore.initializeKeyStore()
 
         try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey1)
@@ -121,7 +121,7 @@ public class ProtectedKeyStoreTests: XCTestCase {
     }
 
     func testImportDataKey() throws {
-        let randomKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as EthPrivateKey
+        let randomKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as Data
         try dataKeyStore.initializeKeyStore()
 
         try dataKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey)
@@ -131,10 +131,10 @@ public class ProtectedKeyStoreTests: XCTestCase {
     }
 
     func testImportDataAndSensitiveKeyStore() throws {
-        let randomSensitiveKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as EthPrivateKey
+        let randomSensitiveKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as Data
         try sensitiveKeyStore.initializeKeyStore()
 
-        let randomDataKey = Data(ethHex: "cb18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c321") as EthPrivateKey
+        let randomDataKey = Data(ethHex: "cb18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c321") as Data
         try dataKeyStore.initializeKeyStore()
 
         try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomSensitiveKey)

--- a/MultisigTests/Features/Security/ProtectedKeyStoreTests.swift
+++ b/MultisigTests/Features/Security/ProtectedKeyStoreTests.swift
@@ -39,7 +39,7 @@ public class ProtectedKeyStoreTests: XCTestCase {
         let randomKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as Data
         try sensitiveKeyStore.initializeKeyStore()
 
-        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey)
+        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), data: randomKey)
 
         let result = try sensitiveKeyStore.find(dataID: DataID(id: "0xE86935943315293154c7AD63296b4e1adAc76364"), password: nil)
         XCTAssertEqual(result?.toHexString(), randomKey.toHexString())
@@ -50,11 +50,11 @@ public class ProtectedKeyStoreTests: XCTestCase {
         let randomKey2 = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c323") as Data
         try sensitiveKeyStore.initializeKeyStore()
 
-        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey1)
+        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), data: randomKey1)
         var result = try sensitiveKeyStore.find(dataID: DataID(id: "0xE86935943315293154c7AD63296b4e1adAc76364"), password: nil)
         XCTAssertEqual(result?.toHexString(), randomKey1.toHexString())
 
-        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey2)
+        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), data: randomKey2)
         result = try sensitiveKeyStore.find(dataID: DataID(id: "0xE86935943315293154c7AD63296b4e1adAc76364"), password: nil)
         XCTAssertEqual(result?.toHexString(), randomKey2.toHexString())
     }
@@ -124,7 +124,7 @@ public class ProtectedKeyStoreTests: XCTestCase {
         let randomKey = Data(ethHex: "da18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c322") as Data
         try dataKeyStore.initializeKeyStore()
 
-        try dataKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomKey)
+        try dataKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), data: randomKey)
 
         let result = try dataKeyStore.find(dataID: DataID(id: "0xE86935943315293154c7AD63296b4e1adAc76364"), password: nil)
         XCTAssertEqual(result?.toHexString(), randomKey.toHexString())
@@ -137,8 +137,8 @@ public class ProtectedKeyStoreTests: XCTestCase {
         let randomDataKey = Data(ethHex: "cb18066dda40499e6ef67a392eda0fd90acf804448a765db9fa9b6e7dd15c321") as Data
         try dataKeyStore.initializeKeyStore()
 
-        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomSensitiveKey)
-        try dataKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), ethPrivateKey: randomDataKey)
+        try sensitiveKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), data: randomSensitiveKey)
+        try dataKeyStore.import(id: DataID(id:"0xE86935943315293154c7AD63296b4e1adAc76364"), data: randomDataKey)
 
         let result = try sensitiveKeyStore.find(dataID: DataID(id: "0xE86935943315293154c7AD63296b4e1adAc76364"), password: nil)
         XCTAssertEqual(result?.toHexString(), randomSensitiveKey.toHexString())


### PR DESCRIPTION
Handles #2828

Changes proposed in this pull request:
- Making the 'enter passcode' work with re-entering wrong passcode
- Making the security lock work for enabling / disabling properly
- Because of new lock method, the 'create passcode' flow changes to first ask for biometry, and if not enabled, then ask for passcode.
- Refactorings in security center
- 🐛 This breaks / disables the 'enable biometry' toggle
- 🏗️ This adds lots of todos and code is not as production
