### PR TITLE
Fix issue cased submit button to be disabled when cancel signing

### DIFF
--- a/Multisig/UI/Transaction/InitiateTransaction/ReviewSafeTransactionViewController/ReviewSafeTransactionViewController.swift
+++ b/Multisig/UI/Transaction/InitiateTransaction/ReviewSafeTransactionViewController/ReviewSafeTransactionViewController.swift
@@ -253,6 +253,7 @@ class ReviewSafeTransactionViewController: UIViewController {
                 } catch {
                     App.shared.snackbar.show(error: GSError.error(description: "Failed to confirm transaction",
                                                                   error: error))
+                    endConfirm()
                 }
             }
 


### PR DESCRIPTION
Handles #2846 

Changes proposed in this pull request:
- Solve issue: If signing was canceled, the submit button won't be enabled 
