### PR TITLE
gh-2900 Execute onPasscodeEnter()

### DIFF
--- a/Multisig/UI/Settings/Passcode/EnterPasscodeViewController.swift
+++ b/Multisig/UI/Settings/Passcode/EnterPasscodeViewController.swift
@@ -10,6 +10,8 @@ import Foundation
 import UIKit
 
 class EnterPasscodeViewController: PasscodeViewController {
+
+    // Deprecated with the new security center
     var passcodeCompletion: (_ success: Bool, _ reset: Bool, _ passcode: String?) -> Void = { _, _, _ in }
 
     var onPasscodeEnter: (_ password: String?) throws -> Void = { _ in }
@@ -72,7 +74,7 @@ class EnterPasscodeViewController: PasscodeViewController {
             do {
                 try onPasscodeEnter(text)
             } catch {
-                LogService.shared.error(error.localizedDescription)
+                onError(error)
             }
         } else {
             wrongAttemptsCount += 1

--- a/Multisig/UI/Settings/Passcode/EnterPasscodeViewController.swift
+++ b/Multisig/UI/Settings/Passcode/EnterPasscodeViewController.swift
@@ -69,6 +69,11 @@ class EnterPasscodeViewController: PasscodeViewController {
 
         if isCorrect {
             passcodeCompletion(true, false, text)
+            do {
+                try onPasscodeEnter(text)
+            } catch {
+                LogService.shared.error(error.localizedDescription)
+            }
         } else {
             wrongAttemptsCount += 1
             if wrongAttemptsCount >= warnAfterWrongAttemptCount {


### PR DESCRIPTION
Handles 

Changes proposed in this pull request:
- Execute onPasscodeEnter to disable or enable the security lock
- This allows to enable/disable the lock
- It allows to switch between FaceId and password
