### PR TITLE
gh-2901 - Use access control flags for keychain items depending on their intended use

### DIFF
--- a/Multisig/Features/Security/ProtectedKeyStore.swift
+++ b/Multisig/Features/Security/ProtectedKeyStore.swift
@@ -101,12 +101,7 @@ class ProtectedKeyStore: EncryptedStore {
 
     func find(dataID: DataID, password derivedPassword: String?, forceUnlock: Bool = false) throws -> Data? {
         guard let encryptedData = try store.find(KeychainItem.generic(account: dataID.id, service: protectionClass.service())) as? Data else {
-
-            // We cannot find/access the encrypted data
-            // This could mean, that the user disabled the device passcode. and reenabled it
-
-            throw GSError.UnknownAppError(description: "Expected data could not be found", reason: "Data is missing", howToFix: "Reset keychain and app data")
-//            return nil
+            return nil
         }
 
         let locked = !unlocked

--- a/Multisig/UI/Settings/Passcode/Create Passcode/CreatePasscodeFlow.swift
+++ b/Multisig/UI/Settings/Passcode/Create Passcode/CreatePasscodeFlow.swift
@@ -186,7 +186,8 @@ class CreatePasscodeFlow: UIFlow {
                     App.shared.snackbar.show(message: "Passcode created")
                     super.stop(success: true)
                 } catch {
-                    App.shared.snackbar.show(message: "Failed to create passcode")
+
+                    App.shared.snackbar.show(message: "Failed to create passcode [](\(error.localizedDescription))")
                     super.stop(success: false)
                 }
             } else {
@@ -200,7 +201,7 @@ class CreatePasscodeFlow: UIFlow {
                     super.stop(success: true)
                     return
                 } catch {
-                    App.shared.snackbar.show(message: "Failed to create passcode")
+                    App.shared.snackbar.show(message: "Failed to create passcode (\(error.localizedDescription))")
                 }
             }
             super.stop(success: false)

--- a/MultisigTests/Features/Security/KeychainItemStoreTests.swift
+++ b/MultisigTests/Features/Security/KeychainItemStoreTests.swift
@@ -11,6 +11,7 @@ class KeychainItemStoreTests: XCTestCase {
 
     var kciStore: KeychainItemStore! = nil
     var kciFactory: KeychainItemFactory = KeychainItemFactory(protectionClass: ProtectionClass.sensitive)
+    var dataKeyFactory: KeychainItemFactory = KeychainItemFactory(protectionClass: ProtectionClass.data)
     let derivedPasscode = "foobar23"
     let passwordTag = "random.tag"
     let encryptedPrivateKeyTag = "random.private.key.tag"
@@ -24,6 +25,7 @@ class KeychainItemStoreTests: XCTestCase {
     public override func tearDown() {
         super.tearDown()
         try! kciStore.delete(kciFactory.generic(account: passwordTag))
+        try! kciStore.delete(dataKeyFactory.generic(account: passwordTag))
         try! kciStore.delete(kciFactory.generic(account: encryptedPrivateKeyTag))
         try! kciStore.delete(kciFactory.ecPubKey())
         try! kciStore.delete(kciFactory.enclaveKey())
@@ -65,6 +67,20 @@ class KeychainItemStoreTests: XCTestCase {
 
         //Then
         let result = try kciStore.find(kciFactory.generic(account: passwordTag)) as! Data?
+        XCTAssertEqual(result, randomString.data(using: .utf8), "Unexpected result: \(result)")
+    }
+
+    func testStoreAndRetrievePasscodeProtectionClassData() throws {
+        // Given
+        let randomString = UUID().uuidString
+        let passCodeData = try kciStore.find(dataKeyFactory.generic(account: passwordTag)) as! Data?
+        XCTAssertEqual(passCodeData, nil, "Keychain not empty")
+
+        // When
+        try kciStore.create(dataKeyFactory.generic(account: passwordTag, data: randomString.data(using: .utf8)))
+
+        //Then
+        let result = try kciStore.find(dataKeyFactory.generic(account: passwordTag)) as! Data?
         XCTAssertEqual(result, randomString.data(using: .utf8), "Unexpected result: \(result)")
     }
 


### PR DESCRIPTION

Handles #2901 

Changes proposed in this pull request:
- Use kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly and kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly