### PR TITLE
gh-2480 - Update applink entitlements

### DIFF
--- a/Multisig/Multisig_DEV.entitlements
+++ b/Multisig/Multisig_DEV.entitlements
@@ -6,8 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:gnosis-safe.io</string>
-		<string>applinks:safe.global</string>
+		<string>applinks:staging.5afe.dev</string>
+		<string>applinks:*.staging.5afe.dev</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Multisig/Multisig_PROD.entitlements
+++ b/Multisig/Multisig_PROD.entitlements
@@ -6,8 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:gnosis-safe.io</string>
 		<string>applinks:safe.global</string>
+		<string>applinks:*.safe.global</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Multisig/Multisig_STAGING.entitlements
+++ b/Multisig/Multisig_STAGING.entitlements
@@ -6,8 +6,8 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:gnosis-safe.io</string>
-		<string>applinks:safe.global</string>
+		<string>applinks:staging.5afe.dev</string>
+		<string>applinks:*.staging.5afe.dev</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
Handles #2480 

Changes proposed in this pull request:
- This change allows for the applink file to be deployed at:  https://staging.5afe.dev/.well-known/apple-app-site-association or https://safe-web-core.staging.5afe.dev/.well-known/apple-app-site-association for staging and dev
- This change allows for the applink file to be deployed at:  https://app.safe.global/.well-known/apple-app-site-association or https://safe.global/.well-known/apple-app-site-association for production

