### PR TITLE
Gh 2920/wc2 session lifecycle

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -888,7 +888,7 @@
 		931AB80628808F3600264AAA /* TransactionPreviewRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931AB80528808F3600264AAA /* TransactionPreviewRequest.swift */; };
 		931B211529BD2CB7009C53B5 /* NativeSocketFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931B211429BD2CB7009C53B5 /* NativeSocketFactory.swift */; };
 		935DCA4C27BD14C600F09EE4 /* WebConnectionDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935DCA4B27BD14C500F09EE4 /* WebConnectionDetailsViewController.swift */; };
-		93788EDC29C356F100503C1A /* DefaultSignerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93788EDB29C356F100503C1A /* DefaultSignerFactory.swift */; };
+		93788EDC29C356F100503C1A /* DummySignerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93788EDB29C356F100503C1A /* DummySignerFactory.swift */; };
 		9388B98227C8DDE400AAB7F5 /* SafeDeploymentNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9388B98127C8DDE400AAB7F5 /* SafeDeploymentNotificationController.swift */; };
 		938D327028C8808D00198B7E /* NavigatingDAOViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938D326E28C8808D00198B7E /* NavigatingDAOViewController.swift */; };
 		938D327128C8808D00198B7E /* NavigatingDAOViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 938D326F28C8808D00198B7E /* NavigatingDAOViewController.xib */; };
@@ -1866,7 +1866,7 @@
 		931AB80528808F3600264AAA /* TransactionPreviewRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionPreviewRequest.swift; sourceTree = "<group>"; };
 		931B211429BD2CB7009C53B5 /* NativeSocketFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSocketFactory.swift; sourceTree = "<group>"; };
 		935DCA4B27BD14C500F09EE4 /* WebConnectionDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebConnectionDetailsViewController.swift; sourceTree = "<group>"; };
-		93788EDB29C356F100503C1A /* DefaultSignerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignerFactory.swift; sourceTree = "<group>"; };
+		93788EDB29C356F100503C1A /* DummySignerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummySignerFactory.swift; sourceTree = "<group>"; };
 		9388B98127C8DDE400AAB7F5 /* SafeDeploymentNotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeDeploymentNotificationController.swift; sourceTree = "<group>"; };
 		938D326E28C8808D00198B7E /* NavigatingDAOViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigatingDAOViewController.swift; sourceTree = "<group>"; };
 		938D326F28C8808D00198B7E /* NavigatingDAOViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NavigatingDAOViewController.xib; sourceTree = "<group>"; };
@@ -2381,7 +2381,7 @@
 				0497B2A929A63BE8007109ED /* WalletConnectManager.swift */,
 				04F8041229A68386007CFF40 /* Proposal.swift */,
 				931B211429BD2CB7009C53B5 /* NativeSocketFactory.swift */,
-				93788EDB29C356F100503C1A /* DefaultSignerFactory.swift */,
+				93788EDB29C356F100503C1A /* DummySignerFactory.swift */,
 			);
 			path = WalletConnectV2;
 			sourceTree = "<group>";
@@ -5100,7 +5100,7 @@
 				550FB1C826691E4A00C13D54 /* ExperimentalViewController.swift in Sources */,
 				0ADD19BF265EA23200EB0F2B /* ExportViewController.swift in Sources */,
 				D88FA81E2770869E0023B77F /* TokenAmountField.swift in Sources */,
-				93788EDC29C356F100503C1A /* DefaultSignerFactory.swift in Sources */,
+				93788EDC29C356F100503C1A /* DummySignerFactory.swift in Sources */,
 				047588182774D6D2001DD992 /* ReviewSendFundsTransactionViewController.swift in Sources */,
 				0A8AEB1025A4712B002A3FE1 /* ActionDetailTextCell.swift in Sources */,
 				0A7AEAF82463190100014184 /* LoadableENSNameText.swift in Sources */,

--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -888,6 +888,7 @@
 		931AB80628808F3600264AAA /* TransactionPreviewRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931AB80528808F3600264AAA /* TransactionPreviewRequest.swift */; };
 		931B211529BD2CB7009C53B5 /* NativeSocketFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931B211429BD2CB7009C53B5 /* NativeSocketFactory.swift */; };
 		935DCA4C27BD14C600F09EE4 /* WebConnectionDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935DCA4B27BD14C500F09EE4 /* WebConnectionDetailsViewController.swift */; };
+		93788EDC29C356F100503C1A /* DefaultSignerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93788EDB29C356F100503C1A /* DefaultSignerFactory.swift */; };
 		9388B98227C8DDE400AAB7F5 /* SafeDeploymentNotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9388B98127C8DDE400AAB7F5 /* SafeDeploymentNotificationController.swift */; };
 		938D327028C8808D00198B7E /* NavigatingDAOViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938D326E28C8808D00198B7E /* NavigatingDAOViewController.swift */; };
 		938D327128C8808D00198B7E /* NavigatingDAOViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 938D326F28C8808D00198B7E /* NavigatingDAOViewController.xib */; };
@@ -1865,6 +1866,7 @@
 		931AB80528808F3600264AAA /* TransactionPreviewRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionPreviewRequest.swift; sourceTree = "<group>"; };
 		931B211429BD2CB7009C53B5 /* NativeSocketFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSocketFactory.swift; sourceTree = "<group>"; };
 		935DCA4B27BD14C500F09EE4 /* WebConnectionDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebConnectionDetailsViewController.swift; sourceTree = "<group>"; };
+		93788EDB29C356F100503C1A /* DefaultSignerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSignerFactory.swift; sourceTree = "<group>"; };
 		9388B98127C8DDE400AAB7F5 /* SafeDeploymentNotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeDeploymentNotificationController.swift; sourceTree = "<group>"; };
 		938D326E28C8808D00198B7E /* NavigatingDAOViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigatingDAOViewController.swift; sourceTree = "<group>"; };
 		938D326F28C8808D00198B7E /* NavigatingDAOViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NavigatingDAOViewController.xib; sourceTree = "<group>"; };
@@ -2379,6 +2381,7 @@
 				0497B2A929A63BE8007109ED /* WalletConnectManager.swift */,
 				04F8041229A68386007CFF40 /* Proposal.swift */,
 				931B211429BD2CB7009C53B5 /* NativeSocketFactory.swift */,
+				93788EDB29C356F100503C1A /* DefaultSignerFactory.swift */,
 			);
 			path = WalletConnectV2;
 			sourceTree = "<group>";
@@ -5097,6 +5100,7 @@
 				550FB1C826691E4A00C13D54 /* ExperimentalViewController.swift in Sources */,
 				0ADD19BF265EA23200EB0F2B /* ExportViewController.swift in Sources */,
 				D88FA81E2770869E0023B77F /* TokenAmountField.swift in Sources */,
+				93788EDC29C356F100503C1A /* DefaultSignerFactory.swift in Sources */,
 				047588182774D6D2001DD992 /* ReviewSendFundsTransactionViewController.swift in Sources */,
 				0A8AEB1025A4712B002A3FE1 /* ActionDetailTextCell.swift in Sources */,
 				0A7AEAF82463190100014184 /* LoadableENSNameText.swift in Sources */,

--- a/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -303,7 +303,7 @@
         "repositoryURL": "https://github.com/WalletConnect/WalletConnectSwiftV2",
         "state": {
           "branch": "main",
-          "revision": "a11d26ce67b422f05505f38584445f16c3510985",
+          "revision": "75944463e6a0d3598b867c81742dd7991ed17bb5",
           "version": null
         }
       },

--- a/Multisig/Cross-layer/Configuration/Config.Example.xcconfig
+++ b/Multisig/Cross-layer/Configuration/Config.Example.xcconfig
@@ -124,9 +124,9 @@ CREATE_SAFE_URL = https:/$()/help.safe.global/en/articles/3876461-create-a-safe
 CONFIRMATIONS_URL = https:/$()/help.safe.global/en/articles/3952319-signature-policies
 
 // Legal URLs
-TERMS_URL       = https:/$()/app.safe.global/terms/
-PRIVACY_URL     = https:/$()/app.safe.global/privacy/
-LICENSES_URL    = https:/$()/safe.global/licenses/
+TERMS_URL       = https:/$()/app.safe.global/terms
+PRIVACY_URL     = https:/$()/app.safe.global/privacy
+LICENSES_URL    = https:/$()/safe.global/licenses
 
 // Contact Information
 DISCORD_URL             = https:/$()/chat.safe.global/

--- a/Multisig/Data/Services/Utils/GSError.swift
+++ b/Multisig/Data/Services/Utils/GSError.swift
@@ -447,6 +447,44 @@ enum GSError {
         let loggable = false
     }
 
+    // MARK: - WalletConnect V2
+
+    struct WC2PairingFailed: DetailedLocalizedError {
+        let description: String = "Pairing failed"
+        let reason = "Unknown"
+        let howToFix = "Please try again later"
+        let domain = clientErrorDomain
+        let code = 9920
+        let loggable = false
+    }
+
+    struct WC2PairingAlreadyExists: DetailedLocalizedError {
+        let description: String = "Pairing failed"
+        let reason = "Pairing already exists"
+        let howToFix = "Please try again with a differrent WalletConnect URL"
+        let domain = clientErrorDomain
+        let code = 9921
+        let loggable = false
+    }
+
+    struct WC2SessionApprovalFailed: DetailedLocalizedError {
+        let description: String = "Session not approved"
+        let reason = "Unknown"
+        let howToFix = "Please try again later"
+        let domain = clientErrorDomain
+        let code = 9930
+        let loggable = false
+    }
+
+    struct WC2SessionApprovalFailedWrongChain: DetailedLocalizedError {
+        let description: String = "Session not approved"
+        let reason = "Wrong chain"
+        let howToFix = "Please use selected Safes' chain"
+        let domain = clientErrorDomain
+        let code = 9931
+        let loggable = false
+    }
+
 	// MARK: Address Book
 
     struct AddressBookEntryAlreadyExists: DetailedLocalizedError {

--- a/Multisig/UI/WalletConnectV2/DefaultSignerFactory.swift
+++ b/Multisig/UI/WalletConnectV2/DefaultSignerFactory.swift
@@ -19,26 +19,18 @@ public struct DefaultSignerFactory: SignerFactory {
 }
 
 public struct Web3Signer: EthereumSigner {
-
+    enum Web3Signer: Error {
+      case shouldNotBeCalledError
+    }
     public func sign(message: Data, with key: Data) throws -> EthereumSignature {
-        let privateKey = try EthereumPrivateKey(privateKey: [UInt8](key))
-        let signature = try privateKey.sign(message: message.bytes)
-        return EthereumSignature(v: UInt8(signature.v), r: signature.r, s: signature.s)
+        throw Web3Signer.shouldNotBeCalledError
     }
 
     public func recoverPubKey(signature: EthereumSignature, message: Data) throws -> Data {
-        let publicKey = try EthereumPublicKey(
-            message: message.bytes,
-            v: EthereumQuantity(quantity: BigUInt(signature.v)),
-            r: EthereumQuantity(signature.r),
-            s: EthereumQuantity(signature.s)
-        )
-        return Data(publicKey.rawPublicKey)
+        throw Web3Signer.shouldNotBeCalledError
     }
 
     public func keccak256(_ data: Data) -> Data {
-        let digest = SHA3(variant: .keccak256)
-        let hash = digest.calculate(for: [UInt8](data))
-        return Data(hash)
+        return Data()
     }
 }

--- a/Multisig/UI/WalletConnectV2/DefaultSignerFactory.swift
+++ b/Multisig/UI/WalletConnectV2/DefaultSignerFactory.swift
@@ -1,0 +1,44 @@
+//
+//  DefaultSignerFactory.swift
+//  Multisig
+//
+//  Created by Dirk Jäckel on 16.03.23.
+//  Copyright © 2023 Gnosis Ltd. All rights reserved.
+//
+
+import Foundation
+import CryptoSwift
+import Web3
+import Auth
+
+public struct DefaultSignerFactory: SignerFactory {
+
+    public func createEthereumSigner() -> EthereumSigner {
+        return Web3Signer()
+    }
+}
+
+public struct Web3Signer: EthereumSigner {
+
+    public func sign(message: Data, with key: Data) throws -> EthereumSignature {
+        let privateKey = try EthereumPrivateKey(privateKey: [UInt8](key))
+        let signature = try privateKey.sign(message: message.bytes)
+        return EthereumSignature(v: UInt8(signature.v), r: signature.r, s: signature.s)
+    }
+
+    public func recoverPubKey(signature: EthereumSignature, message: Data) throws -> Data {
+        let publicKey = try EthereumPublicKey(
+            message: message.bytes,
+            v: EthereumQuantity(quantity: BigUInt(signature.v)),
+            r: EthereumQuantity(signature.r),
+            s: EthereumQuantity(signature.s)
+        )
+        return Data(publicKey.rawPublicKey)
+    }
+
+    public func keccak256(_ data: Data) -> Data {
+        let digest = SHA3(variant: .keccak256)
+        let hash = digest.calculate(for: [UInt8](data))
+        return Data(hash)
+    }
+}

--- a/Multisig/UI/WalletConnectV2/DummySignerFactory.swift
+++ b/Multisig/UI/WalletConnectV2/DummySignerFactory.swift
@@ -11,7 +11,7 @@ import CryptoSwift
 import Web3
 import Auth
 
-public struct DefaultSignerFactory: SignerFactory {
+public struct DummySignerFactory: SignerFactory {
 
     public func createEthereumSigner() -> EthereumSigner {
         return Web3Signer()

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -86,7 +86,7 @@ class WalletConnectManager {
         
         Web3Wallet.instance.sessionDeletePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [unowned self] (topic, reason) in
+            .sink { [unowned self] (topic, _) in
                 deleteStoredSession(topic: topic)
                 NotificationCenter.default.post(name: .wcDidDisconnectSafeServer, object: self)
             }.store(in: &publishers)

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -124,6 +124,9 @@ class WalletConnectManager {
                 try await Web3Wallet.instance.respond(topic: request.topic, requestId: request.id, response: .response(response))
             } catch {
                 print("DAPP: Respond Error: \(error.localizedDescription)")
+                Task { @MainActor in
+                    App.shared.snackbar.show(message: error.localizedDescription)
+                }
             }
         }
     }
@@ -138,6 +141,9 @@ class WalletConnectManager {
                 )
             } catch {
                 print("DAPP: Respond Error: \(error.localizedDescription)")
+                Task { @MainActor in
+                    App.shared.snackbar.show(message: error.localizedDescription)
+                }
             }
         }
     }
@@ -186,6 +192,9 @@ class WalletConnectManager {
         do {
             try await Web3Wallet.instance.extend(topic: session.topic)
         } catch {
+            Task { @MainActor in
+                App.shared.snackbar.show(message: error.localizedDescription)
+            }
             print("DAPP: extending Session error: \(error)")
         }
     }

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -165,12 +165,16 @@ class WalletConnectManager {
                 sessionNamespaces[caip2Namespace] = sessionNamespace
             }
             do {
-                LogService.shared.debug("---> sessionNamesapces: \(sessionNamespaces)")
-                dump(sessionNamespaces)
+//                LogService.shared.debug("---> sessionNamesapces: \(sessionNamespaces)")
+//                dump(sessionNamespaces)
 
                 try await Web3Wallet.instance.approve(proposalId: proposal.id, namespaces: sessionNamespaces)
             } catch {
                 print("DAPP: Approve Session error: \(error)")
+                Task { @MainActor in
+                    App.shared.snackbar.show(message: "\(error)")
+                }
+
             }
         }
     }

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -18,6 +18,7 @@ import Web3Wallet
 import UIKit
 
 class WalletConnectManager {
+    let EVM_COMPATIBLE_NETWORK = "eip155"
     static let shared = WalletConnectManager()
     
     private var publishers = [AnyCancellable]()
@@ -112,7 +113,7 @@ class WalletConnectManager {
             } catch {
                 LogService.shared.error("DAPP: Failed to register to remote notifications \(error)")
                 Task { @MainActor in
-                    App.shared.snackbar.show(message: "DAPP: Failed to register to remote notifications: \(error)")
+                    App.shared.snackbar.show(error: GSError.error(description: "Failed to register to remote notifications: ", error: error))
                 }
             }
         }
@@ -125,7 +126,7 @@ class WalletConnectManager {
             } catch {
                 print("DAPP: Respond Error: \(error.localizedDescription)")
                 Task { @MainActor in
-                    App.shared.snackbar.show(message: "DAPP: Respond Error: \(error)")
+                    App.shared.snackbar.show(error: GSError.error(description: "Respond Error: ", error: error))
                 }
             }
         }
@@ -142,7 +143,7 @@ class WalletConnectManager {
             } catch {
                 print("DAPP: Respond Error: \(error.localizedDescription)")
                 Task { @MainActor in
-                    App.shared.snackbar.show(message: "DAPP: Respond Error: \(error.localizedDescription)")
+                    App.shared.snackbar.show(error: GSError.error(description: "Respond Error: ", error: error))
                 }
             }
         }
@@ -159,7 +160,7 @@ class WalletConnectManager {
                 guard let chains = proposalNamespace.chains else { return }
                 
                 let selectedSafeChain = chains.filter { chain in
-                    chain.namespace == "eip155" && chain.reference == safe.chain?.id
+                    chain.namespace == EVM_COMPATIBLE_NETWORK && chain.reference == safe.chain?.id
                 }
                 
                 let accounts = Set(selectedSafeChain.compactMap {
@@ -176,7 +177,7 @@ class WalletConnectManager {
             } catch {
                 print("DAPP: Approve Session error: \(error)")
                 Task { @MainActor in
-                    App.shared.snackbar.show(message: "DAPP: Approve Session error: \(error)")
+                    App.shared.snackbar.show(error: GSError.error(description: "Approve Session error: ", error: error))
                 }
             }
         }
@@ -189,7 +190,7 @@ class WalletConnectManager {
             try await Web3Wallet.instance.extend(topic: session.topic)
         } catch {
             Task { @MainActor in
-                App.shared.snackbar.show(message: error.localizedDescription)
+                App.shared.snackbar.show(error: GSError.error(description: error.localizedDescription, error: error))
             }
             print("DAPP: extending Session error: \(error)")
         }
@@ -203,8 +204,10 @@ class WalletConnectManager {
             } catch {
                 print("DAPP: disconnecting Session error: \(error)")
                 Task { @MainActor in
-                    App.shared.snackbar.show(message: "DAPP: disconnecting Session error: \(error)")
+                    App.shared.snackbar.show(error: GSError.error(description: "Disconnecting Session error", error: error))
                 }
+
+
             }
             disconnectUnusedPairings()
         }

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -23,7 +23,7 @@ class WalletConnectManager {
     private var publishers = [AnyCancellable]()
     private var dappConnectedTrackingEvent: TrackingEvent?
     private let metadata = AppMetadata(
-        name: Bundle.main.displayName + " (iOS) " + Date().description,
+        name: Bundle.main.displayName + " (iOS) ",
         description: "The most trusted platform to manage digital assets on Ethereum",
         url: App.configuration.services.webAppURL.absoluteString,
         icons: ["https://app.safe.global/favicons/mstile-150x150.png",
@@ -106,7 +106,7 @@ class WalletConnectManager {
         Task {
             do {
                 // Clean up pairings to prevent pairingAlreadyExist error
-                //disconnectUnusedPairings()
+                disconnectUnusedPairings()
                 try await Web3Wallet.instance.pair(uri: uri)
                 NotificationCenter.default.post(name: .wcConnectingSafeServer, object: self)
             } catch {

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -114,9 +114,6 @@ class WalletConnectManager {
                 Task { @MainActor in
                     App.shared.snackbar.show(message: "DAPP: Failed to register to remote notifications: \(error)")
                 }
-                // TODO: What if error is pairingAlreadyExist? or webSocketNotConnected?
-                // Why did we even try to pair if it already esists? Just reuse the pairing?
-                // How to proceed?
             }
         }
     }
@@ -226,20 +223,11 @@ class WalletConnectManager {
 
         sessions.forEach { session in
             pairings = pairings.filter { pairing in
-                if session.pairingTopic == pairing.topic {
-                    LogService.shared.debug("---> Drop: topic: \(session.topic) pairingTopic: \(session.pairingTopic) from list")
-                    return false
-                } else {
-                    LogService.shared.debug("---> Keep: topic: \(session.topic) pairingTopic: \(session.pairingTopic) in list")
-                    return true
-                }
+                session.pairingTopic != pairing.topic
             }
-            dump(pairings, name: "+++> Delete pairings (ongoing)")
         }
-        dump(pairings, name: "+++> Delete pairings (final)")
         pairings.forEach { pairing in
             Task {
-                LogService.shared.debug("---> Deleting pairing: pairing.topic: \(pairing.topic)")
                 try await Web3Wallet.instance.disconnectPairing(topic: pairing.topic)
             }
         }

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -24,7 +24,7 @@ class WalletConnectManager {
     private var dappConnectedTrackingEvent: TrackingEvent?
 
     private let metadata = AppMetadata(
-        name: Bundle.main.displayName,
+        name: Bundle.main.displayName + " (iOS) " + Date().description,
         description: "The most trusted platform to manage digital assets on Ethereum",
         url: App.configuration.services.webAppURL.absoluteString,
         icons: ["https://app.safe.global/favicons/mstile-150x150.png",
@@ -140,6 +140,8 @@ class WalletConnectManager {
     func approveSession(proposal: Session.Proposal) {
         Task {
             guard let safe = try? Safe.getSelected() else { return }
+            LogService.shared.debug("---> requiredNamespaces: \(proposal.requiredNamespaces)")
+            dump(proposal.requiredNamespaces)
             var sessionNamespaces = [String: SessionNamespace]()
             proposal.requiredNamespaces.forEach {
                 let caip2Namespace = $0.key
@@ -156,6 +158,8 @@ class WalletConnectManager {
                 sessionNamespaces[caip2Namespace] = sessionNamespace
             }
             do {
+                LogService.shared.debug("---> sessionNamesapces: \(sessionNamespaces)")
+                dump(sessionNamespaces)
                 try await Sign.instance.approve(proposalId: proposal.id, namespaces: sessionNamespaces)
             } catch {
                 print("DAPP: Approve Session error: \(error)")

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -34,7 +34,7 @@ class WalletConnectManager {
 
     func config() {
         Networking.configure(projectId: App.configuration.walletConnect.walletConnectProjectId,
-                             socketFactory: NativeSocketFactory())
+                             socketFactory: SocketFactory())
         Pair.configure(metadata: metadata)
         setUpAuthSubscribing()
     }
@@ -262,7 +262,6 @@ class WalletConnectManager {
                         let rpcURL = safe.chain!.authenticatedRpcUrl
                         let result = try AnyCodable(any: App.shared.nodeService.rawCall(payload: request.asJSONEncodedString(),
                                                                                         rpcURL: rpcURL))
-                        //let response = try Response(url: request.url, jsonString: result)
                         self.sign(request: request, response: result)
                     } catch {
                         DispatchQueue.main.async {

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -146,16 +146,17 @@ class WalletConnectManager {
         Task {
             guard let safe = try? Safe.getSelected() else { return }
 
-            LogService.shared.debug("---> requiredNamespaces: \(proposal.requiredNamespaces)")
-            dump(proposal.requiredNamespaces)
-
             var sessionNamespaces = [String: SessionNamespace]()
             proposal.requiredNamespaces.forEach {
                 let caip2Namespace = $0.key
                 let proposalNamespace = $0.value
                 guard let chains = proposalNamespace.chains else { return }
 
-                let accounts = Set(chains.compactMap {
+                let selectedSafeChain = chains.filter { chain in
+                    chain.namespace == "eip155" && chain.reference == safe.chain?.id
+                }
+
+                let accounts = Set(selectedSafeChain.compactMap {
                     Account($0.absoluteString + ":\(safe.addressValue)")
                 })
 


### PR DESCRIPTION
Handles #2920

Changes proposed in this pull request:
- Rejects sessions for other networks than the selected Safes network.
- After deleting a session (triggered by user or Dapp) delete unused Pairings (pairings that do nor show up in any sessions pairingTopic)

