### PR TITLE
GH-2970 - Handle pairing already exists

### DIFF
--- a/Multisig/Data/Services/Utils/GSError.swift
+++ b/Multisig/Data/Services/Utils/GSError.swift
@@ -461,7 +461,7 @@ enum GSError {
     struct WC2PairingAlreadyExists: DetailedLocalizedError {
         let description: String = "Pairing failed"
         let reason = "Pairing already exists"
-        let howToFix = "Please try again with a differrent WalletConnect URL"
+        let howToFix = "Please try again with a different QR-Code or WalletConnect URL"
         let domain = clientErrorDomain
         let code = 9921
         let loggable = false

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 import WalletConnectNetworking
 import WalletConnectPairing
+import WalletPairService
 import Combine
 import WalletConnectSign
 import WalletConnectUtils

--- a/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
+++ b/Multisig/UI/WalletConnectV2/WalletConnectManager.swift
@@ -112,7 +112,7 @@ class WalletConnectManager {
             } catch {
                 LogService.shared.error("DAPP: Pairing failed: \(error)")
                 Task { @MainActor in
-                    if "\(error)" == "pairingAlreadyExist" {
+                    if error == WalletPairService.Errors.pairingAlreadyExist {
                         App.shared.snackbar.show(error: GSError.WC2PairingAlreadyExists())
                     } else {
                         App.shared.snackbar.show(error: GSError.WC2PairingFailed())


### PR DESCRIPTION
Handles #2970 

Changes proposed in this pull request:
- More helpful howToFix message
- match on enum type not String
