### PR TITLE
gh-2930 Center total balance labels

### DIFF
--- a/Multisig/UI/Assets/BalancesViewController/TotalBalance/TotalBalanceView.xib
+++ b/Multisig/UI/Assets/BalancesViewController/TotalBalance/TotalBalanceView.xib
@@ -36,13 +36,13 @@
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="eap-t5-4sj">
                                             <rect key="frame" x="0.0" y="0.0" width="436" height="54.5"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total balance" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SnK-Sf-pdr">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Total balance" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SnK-Sf-pdr">
                                                     <rect key="frame" x="0.0" y="0.0" width="436" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U0l-py-63V">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U0l-py-63V">
                                                     <rect key="frame" x="0.0" y="20.5" width="436" height="34"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="34" id="bWc-ow-moD"/>


### PR DESCRIPTION
Handles #2930

Changes proposed in this pull request:

<img src="https://user-images.githubusercontent.com/17750984/226864973-76e2186b-0db6-486d-bb5b-91198dfb5918.png" width=200/>
