### PR TITLE
gh-2988 App crashes when using QR code to connect key via Walletconnect

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/WalletConnectOwnerKey/WalletConnectKeyFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/WalletConnectOwnerKey/WalletConnectKeyFlow.swift
@@ -44,14 +44,13 @@ class WalletConnectKeyFlow: AddKeyFlow {
 
     override func doImport() -> Bool {
         guard let connection = parameters?.connection,
-                let wallet = parameters?.wallet,
                 let name = parameters?.name else {
             assertionFailure("Missing key arguments")
             return false
         }
 
         guard OwnerKeyController.importKey(connection: connection,
-                                           wallet: wallet,
+                                           wallet: parameters?.wallet,
                                            name: name) else {
             WebConnectionController.shared.userDidDisconnect(connection)
             return false


### PR DESCRIPTION
Handles #3017  

Changes proposed in this pull request:
- Wallet can be nil for importKey

