### PR TITLE
gh-3027 Disable fee details editing for sponsored payment option

### DIFF
--- a/Multisig/UI/Transaction/ExecuteTransaction/AmountAndValuePiece.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/AmountAndValuePiece.swift
@@ -21,8 +21,19 @@ class AmountAndValuePiece: UINibView {
         setTextAlignment(.right)
     }
 
-    func setAmount(_ value: String?) {
-        amountLabel.text = value
+    func setAmount(_ value: String?, sponsored: Bool = false) {
+        if value != nil && sponsored {
+            amountLabel.attributedText = NSMutableAttributedString(
+                string: value!,
+                attributes: [
+                    NSAttributedString.Key.foregroundColor: UIColor.labelTertiary,
+                    NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.single.rawValue,
+                    NSAttributedString.Key.strikethroughColor: UIColor.labelTertiary
+                ]
+            )
+        } else {
+            amountLabel.text = value
+        }
     }
 
     func setFiatAmount(_ value: String?) {

--- a/Multisig/UI/Transaction/ExecuteTransaction/AmountAndValuePiece.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/AmountAndValuePiece.swift
@@ -23,13 +23,12 @@ class AmountAndValuePiece: UINibView {
 
     func setAmount(_ value: String?, sponsored: Bool = false) {
         if value != nil && sponsored {
+            var textStyleAttributes = GNOTextStyle.headline.color(.labelTertiary).attributes
+            textStyleAttributes[NSAttributedString.Key.strikethroughColor] = UIColor.labelTertiary
+            textStyleAttributes[NSAttributedString.Key.strikethroughStyle] = NSUnderlineStyle.single.rawValue
             amountLabel.attributedText = NSMutableAttributedString(
                 string: value!,
-                attributes: [
-                    NSAttributedString.Key.foregroundColor: UIColor.labelTertiary,
-                    NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.single.rawValue,
-                    NSAttributedString.Key.strikethroughColor: UIColor.labelTertiary
-                ]
+                attributes: textStyleAttributes
             )
         } else {
             amountLabel.text = value

--- a/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionCellBuilder.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionCellBuilder.swift
@@ -58,10 +58,16 @@ class ReviewExecutionCellBuilder: TransactionDetailCellBuilder {
         paymentGroupCell.tableView.separatorStyle = .none
         let estimatedFeeCell = buildEstimatedGasFee(model.feeState, tableView: paymentGroupCell.tableView)
 
+        var relayerPaymentSelected = false
         if case let .filled(relayerInfo) = model.relayerState,
            relayerInfo.remainingRelays > ReviewExecutionViewController.MIN_RELAY_TXS_LEFT &&
             !userSelectedSigner &&
             safe.chain!.isSupported(feature: .relay) {
+            relayerPaymentSelected = true
+        }
+
+        if relayerPaymentSelected {
+            estimatedFeeCell.accessoryType = .none
             let paymentMethod = buildRelayerPayment(model, tableView: paymentGroupCell.tableView)
             paymentGroupCell.setCells([estimatedFeeCell, paymentMethod])
         } else {
@@ -76,7 +82,9 @@ class ReviewExecutionCellBuilder: TransactionDetailCellBuilder {
             guard let self = self else { return }
             switch index {
             case feeIndex:
-                self.onTapFee()
+                if !relayerPaymentSelected {
+                    self.onTapFee()
+                }
             case paymentIndex:
                 if self.safe.chain!.isSupported(feature: .relay) {
                     self.onTapPaymentMethod()


### PR DESCRIPTION
Handles #3027

Changes proposed in this pull request:
- Disable fee details editing for sponsored payment
- Strike through sponsored amount

<img src="https://user-images.githubusercontent.com/17750984/230403077-d6f7437b-ccba-4386-a7a5-a2aadd244505.png" width=200/>

