### PR TITLE
gh-3032 - Disable create button without key selected on non relay chains

### DIFF
--- a/Multisig/Features/Connect to Wallet/UI/SelectWalletViewController.swift
+++ b/Multisig/Features/Connect to Wallet/UI/SelectWalletViewController.swift
@@ -149,18 +149,7 @@ extension SelectWalletViewController: UITableViewDelegate, UITableViewDataSource
         walletConnectionVC.onSuccess = { [weak self] connection in
             var connectedWallet = wallet
             self?.connection = connection
-            // This means that the connection has been made using the qr code
-            // In such case we don't have selected wallet and we count on the remote peer info to get it
-            // We then have to filter our registry to find out which supported wallet was used
-            if connectedWallet == nil, let name = connection.remotePeer?.name {
-                connectedWallet = self?.walletsSource.wallets(name).first
-            }
-
-            if connectedWallet == nil, let name = connection.remotePeer?.url.absoluteString {
-                connectedWallet = self?.walletsSource.wallets(name).first
-            }
-
-            self?.completion(connectedWallet, connection)
+            self?.completion(wallet, connection)
         }
         let vc = ViewControllerFactory.pageSheet(viewController: walletConnectionVC, halfScreen: wallet != nil)
         present(vc, animated: true)

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeFormUIModel.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeFormUIModel.swift
@@ -119,18 +119,22 @@ class CreateSafeFormUIModel {
     }
 
     var isCreateEnabled: Bool {
-        (state == .ready || (state == .keyNotFound && userSelectedPaymentMethod == .relayer)) &&
+        (state == .ready || (state == .keyNotFound && userSelectedRelayerAndItIsAvailableForChain)) &&
         name != nil &&
         !name!.isEmpty &&
         chain != nil &&
         !owners.isEmpty &&
         threshold > 0 &&
         threshold <= owners.count &&
-        (selectedKey != nil || userSelectedPaymentMethod == .relayer) &&
+        (selectedKey != nil || userSelectedRelayerAndItIsAvailableForChain) &&
         transaction != nil &&
-        (deployerBalance != nil || userSelectedPaymentMethod == .relayer) &&
-        (deployerBalance! >= transaction.requiredBalance || userSelectedPaymentMethod == .relayer) &&
+        (deployerBalance != nil || userSelectedRelayerAndItIsAvailableForChain) &&
+        (deployerBalance! >= transaction.requiredBalance || userSelectedRelayerAndItIsAvailableForChain) &&
         error == nil
+    }
+
+    var userSelectedRelayerAndItIsAvailableForChain: Bool {
+        userSelectedPaymentMethod == .relayer && chain.isSupported(feature: .relayingMobile)
     }
 
     var isLoadingDeployer: Bool {

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -697,6 +697,7 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
         let choosePaymentVC = ChoosePaymentViewController()
         choosePaymentVC.relaysRemaining = relaysRemaining
         choosePaymentVC.relaysLimit = relaysLimit
+        choosePaymentVC.userSelectedSigner = uiModel.userSelectedPaymentMethod == .signerAccount
 
         choosePaymentVC.chooseRelay = { [unowned self] in
             LogService.shared.debug("User selected Relay")

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -221,11 +221,16 @@ class OwnerKeyDetailsViewController: UITableViewController, WebConnectionObserve
             self.sections.append((section: .connected("WC CONNECTION"), items: [Section.Connected.connected]))
         }
 
-        self.sections.append((section: .pushNotificationConfiguration("PUSH NOTIFICATIONS"),
-                              items: [Section.PushNotificationConfiguration.enabled]))
-        if self.keyInfo.delegateAddress != nil {
+        // TODO: Remove this after release 3.19.0
+        if ![KeyType.deviceImported, KeyType.deviceImported].contains(keyInfo.keyType) {
+            self.sections.append((section: .pushNotificationConfiguration("PUSH NOTIFICATIONS"),
+                                  items: [Section.PushNotificationConfiguration.enabled]))
+        }
+
+        if self.keyInfo.delegateAddress != nil &&
+            ![KeyType.deviceImported, KeyType.deviceImported].contains(keyInfo.keyType) {
             self.sections.append((section: .delegateKey("DELEGATE KEY ADDRESS"),
-                                  items: [Section.DelegateKey.address, Section.DelegateKey.helpLink]))
+                    items: [Section.DelegateKey.address, Section.DelegateKey.helpLink]))
         }
 
         self.sections.append((section: .advanced, items: [Section.Advanced.remove]))

--- a/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/OwnerKeyDetailsViewController/OwnerKeyDetailsViewController.swift
@@ -222,13 +222,13 @@ class OwnerKeyDetailsViewController: UITableViewController, WebConnectionObserve
         }
 
         // TODO: Remove this after release 3.19.0
-        if ![KeyType.deviceImported, KeyType.deviceImported].contains(keyInfo.keyType) {
+        if ![KeyType.deviceImported, KeyType.deviceGenerated].contains(keyInfo.keyType) {
             self.sections.append((section: .pushNotificationConfiguration("PUSH NOTIFICATIONS"),
                                   items: [Section.PushNotificationConfiguration.enabled]))
         }
 
         if self.keyInfo.delegateAddress != nil &&
-            ![KeyType.deviceImported, KeyType.deviceImported].contains(keyInfo.keyType) {
+            ![KeyType.deviceImported, KeyType.deviceGenerated].contains(keyInfo.keyType) {
             self.sections.append((section: .delegateKey("DELEGATE KEY ADDRESS"),
                     items: [Section.DelegateKey.address, Section.DelegateKey.helpLink]))
         }

--- a/Multisig/UI/Settings/OwnerKeyManagement/WalletConnectOwnerKey/WalletConnectKeyFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/WalletConnectOwnerKey/WalletConnectKeyFlow.swift
@@ -44,14 +44,13 @@ class WalletConnectKeyFlow: AddKeyFlow {
 
     override func doImport() -> Bool {
         guard let connection = parameters?.connection,
-                let wallet = parameters?.wallet,
-                let name = parameters?.name else {
+              let name = parameters?.name else {
             assertionFailure("Missing key arguments")
             return false
         }
 
         guard OwnerKeyController.importKey(connection: connection,
-                                           wallet: wallet,
+                                           wallet: parameters?.wallet,
                                            name: name) else {
             WebConnectionController.shared.userDidDisconnect(connection)
             return false


### PR DESCRIPTION
Handles #3032

Changes proposed in this pull request:
- Only enabled create button when relaying is avaliabe regardless of the initial selection of relay

