### PR TITLE
gh-3058 Remove all entitlements except for the respective host

### DIFF
--- a/Multisig/Multisig_DEV.entitlements
+++ b/Multisig/Multisig_DEV.entitlements
@@ -6,8 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:staging.5afe.dev</string>
-		<string>applinks:*.staging.5afe.dev</string>
 		<string>applinks:safe-web-core.staging.5afe.dev</string>
 	</array>
 	<key>com.apple.security.application-groups</key>

--- a/Multisig/Multisig_PROD.entitlements
+++ b/Multisig/Multisig_PROD.entitlements
@@ -6,8 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:safe.global</string>
-		<string>applinks:*.safe.global</string>
 		<string>applinks:app.safe.global</string>
 	</array>
 	<key>com.apple.security.application-groups</key>

--- a/Multisig/Multisig_STAGING.entitlements
+++ b/Multisig/Multisig_STAGING.entitlements
@@ -6,8 +6,6 @@
 	<string>development</string>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:staging.5afe.dev</string>
-		<string>applinks:*.staging.5afe.dev</string>
 		<string>applinks:safe-web-core.staging.5afe.dev</string>
 	</array>
 	<key>com.apple.security.application-groups</key>


### PR DESCRIPTION
Handles #3058

Changes proposed in this pull request:
- Remove entitlement for *.safe.global and safe.global for prod app
- Remove entitlement for *.staging.5afe.dev  and staging.5afe.dev for staging app