### PR TITLE
gh-2900 Keep data store always unlocked after password change

### DIFF
--- a/Multisig/Features/Security/EncryptedStore.swift
+++ b/Multisig/Features/Security/EncryptedStore.swift
@@ -21,7 +21,7 @@ protocol EncryptedStore {
     /// - parameter password: application password. Can be nil, then the stored password is used
     /// - returns: String with hex encoded bytes of the private key or nil if key not found
     func find(dataID: DataID, password: String?, forceUnlock: Bool) throws -> Data?
-    func changePassword(from oldPassword: String?, to newPassword: String?, useBiometry: Bool) throws
+    func changePassword(from oldPassword: String?, to newPassword: String?, useBiometry: Bool, keepUnlocked: Bool) throws
 
     func deleteAllKeys() throws
 }

--- a/Multisig/Features/Security/ProtectedKeyStore.swift
+++ b/Multisig/Features/Security/ProtectedKeyStore.swift
@@ -179,7 +179,7 @@ class ProtectedKeyStore: EncryptedStore {
         )
         try store.create(pubKeyItem)
 
-        if locked {
+        if locked && self.protectionClass != .data {
             lock()
         }
     }

--- a/Multisig/Features/Security/ProtectedKeyStore.swift
+++ b/Multisig/Features/Security/ProtectedKeyStore.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class ProtectedKeyStore: EncryptedStore {
 
-    private let protectionClass: ProtectionClass
+    let protectionClass: ProtectionClass
     private let store: KeychainItemStore
 
     static let publicKeyTag = "global.safe.publicKeyTag"
@@ -125,11 +125,11 @@ class ProtectedKeyStore: EncryptedStore {
     //                        oldPassword == nil -> use stored password to access current KEK
     //                        newPassword == nil -> use stored password to access KEK
     //          useBiometry -> true/false
-    func changePassword(from oldPassword: String?, to newPassword: String?, useBiometry: Bool = false) throws {
+    func changePassword(from oldPassword: String?, to newPassword: String?, useBiometry: Bool = false, keepUnlocked: Bool = false) throws {
 
-        let locked = !unlocked
+        let wasLocked = !unlocked
 
-        if locked {
+        if wasLocked {
             try unlock(derivedPassword: oldPassword)
         }
 
@@ -179,7 +179,7 @@ class ProtectedKeyStore: EncryptedStore {
         )
         try store.create(pubKeyItem)
 
-        if locked && self.protectionClass != .data {
+        if wasLocked && !keepUnlocked {
             lock()
         }
     }

--- a/Multisig/Features/Security/SecurityCenter.swift
+++ b/Multisig/Features/Security/SecurityCenter.swift
@@ -278,7 +278,7 @@ class SecurityCenter {
             newStorePassword = nil
             biometryUsed = false
         }
-        try store.changePassword(from: currentDerivedPassword, to: newStorePassword, useBiometry: biometryUsed)
+        try store.changePassword(from: currentDerivedPassword, to: newStorePassword, useBiometry: biometryUsed, keepUnlocked: store.protectionClass == .data)
     }
 
     // TODO: cancelling is not an error? success = false means cancelled?


### PR DESCRIPTION
Handles #2900

Changes proposed in this pull request:
- When changing the password or lock mechanism, the data store should be unlocked afterwards
