### PR TITLE
[iOS] Web app staging host changed. 

### DIFF
--- a/Multisig/Multisig_DEV.entitlements
+++ b/Multisig/Multisig_DEV.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:safe-web-core.staging.5afe.dev</string>
+		<string>applinks:safe-wallet-web.staging.5afe.dev</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/Multisig/Multisig_STAGING.entitlements
+++ b/Multisig/Multisig_STAGING.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:safe-web-core.staging.5afe.dev</string>
+		<string>applinks:safe-wallet-web.staging.5afe.dev</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
Keep the old name for links that were previously generated.