### PR TITLE
gh-3011 Account for long title: allow 2 lines

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddKeyAsOwnerIntroViewController.xib
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddKeyAsNewOwner/AddKeyAsOwnerIntroViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
@@ -21,29 +21,29 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="9fk-l3-vUr">
-                    <rect key="frame" x="24" y="48" width="366" height="674"/>
+                    <rect key="frame" x="24" y="0.0" width="272" height="428"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="u7X-vb-oik">
-                            <rect key="frame" x="0.0" y="238.5" width="366" height="197.5"/>
+                            <rect key="frame" x="0.0" y="95" width="272" height="238"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ico-add-key-as-owner" translatesAutoresizingMaskIntoConstraints="NO" id="wvT-gI-IHI">
-                                    <rect key="frame" x="129" y="0.0" width="108" height="96"/>
+                                    <rect key="frame" x="82" y="0.0" width="108" height="96"/>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="ha0-kD-2hc">
-                                    <rect key="frame" x="16.5" y="120" width="333.5" height="77.5"/>
+                                    <rect key="frame" x="4.5" y="120" width="263" height="118"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Make this key a Safe Account owner?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MSh-bG-n3T">
-                                            <rect key="frame" x="25.5" y="0.0" width="282.5" height="20.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Make this key a Safe Account owner?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MSh-bG-n3T">
+                                            <rect key="frame" x="51.5" y="0.0" width="160" height="41"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Making it an owner will let you use it to take action with the selected Safe Account." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9ep-eq-8q8">
-                                            <rect key="frame" x="0.0" y="36.5" width="333.5" height="41"/>
+                                            <rect key="frame" x="0.0" y="57" width="263" height="61"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -55,7 +55,7 @@
                     </subviews>
                 </stackView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y3d-Vb-bSi">
-                    <rect key="frame" x="16" y="722" width="382" height="56"/>
+                    <rect key="frame" x="16" y="428" width="288" height="56"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="56" id="vjp-q8-MX1"/>
                     </constraints>
@@ -68,7 +68,7 @@
                     </connections>
                 </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kUQ-bK-HnV">
-                    <rect key="frame" x="16" y="786" width="382" height="56"/>
+                    <rect key="frame" x="16" y="492" width="288" height="56"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="56" id="uZQ-lc-mXU"/>
                     </constraints>


### PR DESCRIPTION
Handles #3011

Changes proposed in this pull request:
- prevent title ellipsizing by allowing it to occupy 2 lines
- center title text
<img width="185" alt="image" src="https://github.com/safe-global/safe-ios/assets/17750984/00ccf46f-98f8-4442-8fe8-e83d7cbb3ca4">
