### PR TITLE
gh-3171 Make message multiline

### DIFF
--- a/Multisig/UI/Safe Management/Create Safe/SafeDeployingViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/SafeDeployingViewController.swift
@@ -21,8 +21,6 @@ class SafeDeployingViewController: UIViewController {
     var containerViewYConstraint: NSLayoutConstraint?
     var txHash: String?
 
-    var timer: Timer?
-
     override func viewDidLoad() {
         super.viewDidLoad()
         statusLabel.setStyle(.title3)
@@ -41,16 +39,6 @@ class SafeDeployingViewController: UIViewController {
 
         reloadData()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        timer = Timer.scheduledTimer(timeInterval: 3, target: self, selector: #selector(updateStatus), userInfo: nil, repeats: true)
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        timer?.invalidate()
-    }
 
     @objc func reloadData() {
         guard let safe = try? Safe.getSelected() else {
@@ -68,7 +56,6 @@ class SafeDeployingViewController: UIViewController {
         }
 
         txButton.isHidden = txHash == nil
-        updateStatus()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -92,26 +79,10 @@ class SafeDeployingViewController: UIViewController {
         }
     }
 
-    @objc func updateStatus() {
-        statusLabel.pushTransition(1)
-    }
-
     @IBAction func didTapViewTransaction(_ sender: Any) {
         Tracker.trackEvent(.createSafeViewTxOnEtherscan)
         if let txHash = txHash, let chain = safe?.chain {
             openInSafari(chain.browserURL(txHash: txHash))
         }
-    }
-}
-
-extension UIView {
-    func pushTransition(_ duration: CFTimeInterval) {
-        let animation:CATransition = CATransition()
-        animation.timingFunction = CAMediaTimingFunction(name:
-            CAMediaTimingFunctionName.easeInEaseOut)
-        animation.type = CATransitionType.push
-        animation.duration = duration
-        animation.subtype = .fromTop
-        layer.add(animation, forKey: CATransitionType.push.rawValue)
     }
 }

--- a/Multisig/UI/Safe Management/Create Safe/SafeDeployingViewController.xib
+++ b/Multisig/UI/Safe Management/Create Safe/SafeDeployingViewController.xib
@@ -40,7 +40,7 @@
                                                 <constraint firstAttribute="height" constant="110" id="a7K-A4-o3N"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We are preparing your Safe Account..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rn6-Av-315">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="We are preparing your Safe Account..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rn6-Av-315">
                                             <rect key="frame" x="0.0" y="180.5" width="310" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>


### PR DESCRIPTION
Handles #3171 

Changes proposed in this pull request:
- Show the full message on smaller width screens

before | after 
-------| ------
![image (10)](https://github.com/safe-global/safe-ios/assets/246473/b2679b86-64d3-4e5d-9852-a65539a4004d) | <img width="347" alt="image" src="https://github.com/safe-global/safe-ios/assets/246473/3937aad1-0aed-4b10-ad80-3e7c247c9dbc">

