### PR TITLE
GH-2988 weakify the references in closures

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/GenerateOwnerKey/AddKeyFlow.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/GenerateOwnerKey/AddKeyFlow.swift
@@ -115,8 +115,8 @@ class AddKeyFlow: UIFlow {
             return
         }
 
-        let vc = factory.keyNotification(for: address, name: name, type: type) { [unowned self] in
-            didDelegateKeySetup()
+        let vc = factory.keyNotification(for: address, name: name, type: type) { [weak self] in
+            self?.didDelegateKeySetup()
         }
 
         show(vc)


### PR DESCRIPTION
Handles #2988

Changes proposed in this pull request:
- `[weak self]` references related to the crash location
- fix crash from clicking `remove owner key` on mac