### PR TITLE
GH-3297 support current web app url format

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -999,6 +999,7 @@
 		B0D61F54F176906A7C5A65CB /* SendTransactionRequestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D61BDFEADB74805D9221DB /* SendTransactionRequestViewController.swift */; };
 		B0D61FFF1935AA2484BD940A /* WebConnectionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D617C60F3081A3A923005D /* WebConnectionRepository.swift */; };
 		B343BEB32A77DDA1006BF46B /* DMSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0491067C28F99246005A4A99 /* DMSans-Bold.ttf */; };
+		B35BFD0F2A937DC000A9FB15 /* DefaultNavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35BFD0E2A937DC000A9FB15 /* DefaultNavigationRouterTests.swift */; };
 		B3B6044F2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B6044E2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift */; };
 		D80B5A032769CEAD00D6E024 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80B5A022769CEAD00D6E024 /* Tooltip.swift */; };
 		D80B5A052769CF1B00D6E024 /* TooltipSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80B5A042769CF1B00D6E024 /* TooltipSource.swift */; };
@@ -2023,6 +2024,7 @@
 		B0D61DB08E699747DCEE7325 /* GnosisSafeWebPeerInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GnosisSafeWebPeerInfo.swift; sourceTree = "<group>"; };
 		B0D61EF933B18A7181F0F6E8 /* WebConnectionOpenRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebConnectionOpenRequest.swift; sourceTree = "<group>"; };
 		B0D61FB05FC8C6D45FAC1246 /* ActionPanelView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ActionPanelView.xib; sourceTree = "<group>"; };
+		B35BFD0E2A937DC000A9FB15 /* DefaultNavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultNavigationRouterTests.swift; sourceTree = "<group>"; };
 		B3B6044E2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertControllerStyle+Multiplatform.swift"; sourceTree = "<group>"; };
 		D80B5A022769CEAD00D6E024 /* Tooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tooltip.swift; sourceTree = "<group>"; };
 		D80B5A042769CF1B00D6E024 /* TooltipSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipSource.swift; sourceTree = "<group>"; };
@@ -2674,6 +2676,7 @@
 				551DDEEA244F192300C719D3 /* Models */,
 				0A9366BC279090CC001918A9 /* OwnerKeySelectionPolicyTests.swift */,
 				0AADCDBF2858CE2600A0139B /* AddOwnerRequestValidatorTests.swift */,
+				B35BFD0E2A937DC000A9FB15 /* DefaultNavigationRouterTests.swift */,
 			);
 			path = Logic;
 			sourceTree = "<group>";
@@ -3278,7 +3281,6 @@
 		0A93DD6F2445CC8C00688050 /* MultisigTests */ = {
 			isa = PBXGroup;
 			children = (
-				D86A68E2274E6B3E00D7F5C5 /* App */,
 				0A0EFCA3246EADE900D3D8BF /* Logic */,
 				0A0EFCA1246EADD100D3D8BF /* Data */,
 				0A0EFCA2246EADE200D3D8BF /* Cross-layer */,
@@ -4636,13 +4638,6 @@
 			path = ExecuteTransaction;
 			sourceTree = "<group>";
 		};
-		D86A68E2274E6B3E00D7F5C5 /* App */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -5836,6 +5831,7 @@
 				5532D4CE2449A1980067505A /* ConsoleLoggerTests.swift in Sources */,
 				0AA9F25924992CB6005BD60F /* TransactionTests.swift in Sources */,
 				0ADD04D6268CB9BF00C2B44A /* UIColorStylesTests.swift in Sources */,
+				B35BFD0F2A937DC000A9FB15 /* DefaultNavigationRouterTests.swift in Sources */,
 				0A9366BD279090CD001918A9 /* OwnerKeySelectionPolicyTests.swift in Sources */,
 				0A096CC82608F49E0034E6BC /* RegisterNotificationTokenRequestTests.swift in Sources */,
 				5532D4CB2449A1980067505A /* LoggableErrorTests.swift in Sources */,

--- a/Multisig/App/SceneDelegate.swift
+++ b/Multisig/App/SceneDelegate.swift
@@ -176,12 +176,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // handle request to add owner
         if AddOwnerRequestValidator.isValid(url: incomingURL),
            let params = AddOwnerRequestValidator.parameters(from: incomingURL) {
-            DefaultNavigationRouter.shared.navigate(to: .requestToAddOwner(params))
+            CompositeNavigationRouter.shared.navigate(to: .requestToAddOwner(params))
             return
         }
 
-        if let navigationRoute = DefaultNavigationRouter.shared.routeFrom(from: incomingURL) {
-            DefaultNavigationRouter.shared.navigate(to: navigationRoute)
+        if let navigationRoute = CompositeNavigationRouter.shared.routeFrom(from: incomingURL) {
+            CompositeNavigationRouter.shared.navigate(to: navigationRoute)
         }
     }
 
@@ -384,6 +384,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 
 extension SceneDelegate: NavigationRouter {
+    func routeFrom(from url: URL) -> NavigationRoute? {
+        nil
+    }
+    
     func canNavigate(to route: NavigationRoute) -> Bool {
         guard let tabWindow = tabBarWindow, let tabBarVC = tabWindow.rootViewController as? MainTabBarViewController else { return false }
         return tabBarVC.canNavigate(to: route)

--- a/Multisig/Features/Connect to Web/UI/List/WebConnectionsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/List/WebConnectionsViewController.swift
@@ -212,6 +212,10 @@ extension WebConnectionsViewController: QRCodeScannerViewControllerDelegate {
 }
 
 extension WebConnectionsViewController: NavigationRouter {
+    func routeFrom(from url: URL) -> NavigationRoute? {
+        nil
+    }
+    
     func canNavigate(to route: NavigationRoute) -> Bool {
         route.path == NavigationRoute.connectToWeb().path
     }

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -402,6 +402,8 @@ extension MainTabBarViewController: NavigationRouter {
             return true
         } else if route.path == NavigationRoute.showAssets().path {
             return true
+        } else if route.path == NavigationRoute.showCollectibles().path {
+            return true
         } else if route.path == NavigationRoute.deploymentFailedPath {
             return true
         } else if route.path == NavigationRoute.requestToAddOwnerPath {
@@ -437,20 +439,11 @@ extension MainTabBarViewController: NavigationRouter {
                 }
             }
         } else if route.path == NavigationRoute.showAssets().path {
-            // if there is address and chain id, then switch to that safe.
-            //      if such safe doesn't exist, then do nothing.
-            // if no parameters passed, just switch to balances.
-            if let rawAddress = route.info["address"] as? String,
-               let rawChainId = route.info["chainId"] as? String {
-                guard let safe = Safe.by(address: rawAddress, chainId: rawChainId) else {
-                    // don't navigate, exit because the route can't work.
-                    return
-                }
-                if !safe.isSelected {
-                    safe.select()
-                }
-            }
+            guard selectSafe(from: route) else { return }
             switchTo(indexPath: Path.balances)
+        } else if route.path == NavigationRoute.showCollectibles().path {
+            guard selectSafe(from: route) else { return }
+            switchTo(indexPath: Path.collectibles)
         } else if route.path == NavigationRoute.deploymentFailedPath {
             presentFailedDeployment(safe: route.info["safe"] as! Safe)
         } else if route.path == NavigationRoute.requestToAddOwnerPath {
@@ -463,6 +456,24 @@ extension MainTabBarViewController: NavigationRouter {
 
             present(flow: addOwnerFlow)
         }
+    }
+    
+    
+    // if there is address and chain id, then switch to that safe.
+    //      if such safe doesn't exist, then do nothing.
+    // if no parameters passed, just switch to balances.
+    private func selectSafe(from route: NavigationRoute) -> Bool {
+        if let rawAddress = route.info["address"] as? String,
+           let rawChainId = route.info["chainId"] as? String {
+            guard let safe = Safe.by(address: rawAddress, chainId: rawChainId) else {
+                // don't navigate, exit because the route can't work.
+                return false
+            }
+            if !safe.isSelected {
+                safe.select()
+            }
+        }
+        return true
     }
 
     func switchTo(indexPath: IndexPath) {
@@ -479,6 +490,9 @@ extension MainTabBarViewController: NavigationRouter {
 
         switch index {
         case Path.assets.first:
+            switchAssets(segment: segment)
+            
+        case Path.collectibles.last:
             switchAssets(segment: segment)
 
         case Path.transactions.first:

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -391,6 +391,10 @@ class MainTabBarViewController: UITabBarController {
 }
 
 extension MainTabBarViewController: NavigationRouter {
+    func routeFrom(from url: URL) -> NavigationRoute? {
+        nil
+    }
+    
     func canNavigate(to route: NavigationRoute) -> Bool {
         if route.path.starts(with: "/settings/") {
             return true

--- a/Multisig/UI/App/NavigationRouter.swift
+++ b/Multisig/UI/App/NavigationRouter.swift
@@ -130,6 +130,8 @@ class ExtendedNavigationRouter: NavigationRouter {
     func routeFrom(from url: URL) -> NavigationRoute? {
         
         switch url.path {
+        case "/welcome", "/home":
+            return NavigationRoute.showAssets()
         case "/balances":
             guard let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url) else {
                 return nil

--- a/Multisig/UI/App/NavigationRouter.swift
+++ b/Multisig/UI/App/NavigationRouter.swift
@@ -14,6 +14,7 @@ struct NavigationRoute {
 protocol NavigationRouter {
     func canNavigate(to route: NavigationRoute) -> Bool
     func navigate(to route: NavigationRoute)
+    func routeFrom(from url: URL) -> NavigationRoute?
 }
 
 extension NavigationRouter {
@@ -21,6 +22,43 @@ extension NavigationRouter {
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
             navigate(to: route)
         }
+    }
+}
+
+class CompositeNavigationRouter: NavigationRouter {
+    static let shared = CompositeNavigationRouter(routers: [ExtendedNavigationRouter(), DefaultNavigationRouter()])
+    
+    private var routers: [NavigationRouter]
+
+    init(routers: [NavigationRouter]) {
+        self.routers = routers
+    }
+    
+    func canNavigate(to route: NavigationRoute) -> Bool {
+        for router in routers {
+            if router.canNavigate(to: route) {
+                return true
+            }
+        }
+        return false
+    }
+    
+    func navigate(to route: NavigationRoute) {
+        for router in routers {
+            if router.canNavigate(to: route) {
+                router.navigate(to: route)
+                return
+            }
+        }
+    }
+    
+    func routeFrom(from url: URL) -> NavigationRoute? {
+        for router in routers {
+            if let route = router.routeFrom(from: url) {
+                return route
+            }
+        }
+        return nil
     }
 }
 
@@ -40,12 +78,12 @@ class DefaultNavigationRouter: NavigationRouter {
         sceneDelegate?.navigate(to: route)
     }
 
-    private let pattern = "^\(App.configuration.services.webAppURL)([-a-zA-Z0-9]{1,20}):(0x[a-fA-F0-9]{40})/([-a-zA-Z0-9]{1,20})(/[-a-zA-Z0-9_]+)?"
+    private let pattern = "^https://.*/([-a-zA-Z0-9]{1,20}):(0x[a-fA-F0-9]{40})/([-a-zA-Z0-9]{1,20})(/[-a-zA-Z0-9_]+)?"
 
     func routeFrom(from url: URL) -> NavigationRoute? {
         let matches = url.absoluteString.capturedValues(pattern: pattern).flatMap { $0 }
         guard matches.count >= 3,
-                let ـ = Address(matches[1]),
+                let _ = Address(matches[1]),
               let chain = Chain.by(shortName: matches[0]) else { return nil }
 
         let safeAddress = matches[1]
@@ -70,6 +108,102 @@ class DefaultNavigationRouter: NavigationRouter {
         return nil
     }
 }
+
+class ExtendedNavigationRouter: NavigationRouter {
+    static let shared = ExtendedNavigationRouter()
+
+    private var sceneDelegate: SceneDelegate? {
+        UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+    }
+
+    func canNavigate(to route: NavigationRoute) -> Bool {
+        guard let sceneDelegate = sceneDelegate else { return false }
+        return sceneDelegate.canNavigate(to: route)
+    }
+
+    func navigate(to route: NavigationRoute) {
+        sceneDelegate?.navigate(to: route)
+    }
+
+    private let pattern = "^https://.*/([-a-zA-Z0-9]{1,20})(/[-a-zA-Z0-9_]+)?"
+
+    func routeFrom(from url: URL) -> NavigationRoute? {
+        
+        switch url.path {
+        case "/balances":
+            guard let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url) else {
+                return nil
+            }
+            let route = NavigationRoute.showAssets(
+                safeAddress.address,
+                chainId: safeAddress.chainId
+            )
+            return route
+        case "/transactions/history":
+            guard let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url) else {
+                return nil
+            }
+            let route = NavigationRoute.showTransactionHistory(
+                safeAddress.address,
+                chainId: safeAddress.chainId
+            )
+            return route
+        case "/transactions/queue":
+            guard let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url) else {
+                return nil
+            }
+            let route = NavigationRoute.showTransactionQueued(
+                safeAddress.address,
+                chainId: safeAddress.chainId
+            )
+            return route
+        case "/transactions/tx":
+            guard
+                let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url),
+                let transactionId = queryParameterValue(named: "id", in: url)
+            else {
+                return nil
+            }
+            let route = NavigationRoute.showTransactionDetails(
+                safeAddress.address,
+                chainId: safeAddress.chainId,
+                transactionId: transactionId
+            )
+            return route
+
+        default:
+            return nil
+        }
+    }
+    
+    // get the address and chain id from the 'safe'
+    private func eip3770AddressQueryParameter(named name: String, in url: URL) -> (address: String, chainId: String)? {
+        guard
+            let paramValue = queryParameterValue(named: name, in: url),
+            let address = try? Address.addressWithPrefix(text: paramValue),
+            let prefix = address.prefix,
+            let chainId = Chain.by(shortName: prefix)?.id
+        else {
+            return nil
+        }
+        return (address.checksummed, chainId)
+    }
+
+    // get the value of a query parameter
+    private func queryParameterValue(named name: String, in url: URL) -> String? {
+        let urlComps = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let items = urlComps?.queryItems
+        guard
+            let paramValue = items?.first(where: { item in
+                item.name == name
+            })?.value
+        else {
+            return nil
+        }
+        return paramValue
+    }
+}
+
 
 extension NavigationRoute {
     static func connectToWeb(_ code: String? = nil) -> NavigationRoute {

--- a/Multisig/UI/App/NavigationRouter.swift
+++ b/Multisig/UI/App/NavigationRouter.swift
@@ -139,6 +139,15 @@ class ExtendedNavigationRouter: NavigationRouter {
                 chainId: safeAddress.chainId
             )
             return route
+        case "/balances/nfts":
+            guard let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url) else {
+                return nil
+            }
+            let route = NavigationRoute.showCollectibles(
+                safeAddress.address,
+                chainId: safeAddress.chainId
+            )
+            return route
         case "/transactions/history":
             guard let safeAddress = eip3770AddressQueryParameter(named: "safe", in: url) else {
                 return nil
@@ -216,6 +225,17 @@ extension NavigationRoute {
 
     static func showAssets(_ address: String? = nil, chainId: String? = nil) -> NavigationRoute {
         var route = NavigationRoute(path: "/assets/")
+        if let address = address,
+           let chainId = chainId {
+            route.info["address"] = address
+            route.info["chainId"] = chainId
+        }
+
+        return route
+    }
+    
+    static func showCollectibles(_ address: String? = nil, chainId: String? = nil) -> NavigationRoute {
+        var route = NavigationRoute(path: "/assets/collectibles/")
         if let address = address,
            let chainId = chainId {
             route.info["address"] = address

--- a/Multisig/UI/Dapps/DappsViewController.swift
+++ b/Multisig/UI/Dapps/DappsViewController.swift
@@ -284,9 +284,7 @@ extension DappsViewController: QRCodeScannerViewControllerDelegate {
         if (url.starts(with: "safe-wc:")) {
             dismiss(animated: true) {
                 let route = NavigationRoute.connectToWeb(url)
-                if DefaultNavigationRouter.shared.canNavigate(to: route) {
-                    DefaultNavigationRouter.shared.navigate(to: route)
-                }
+                CompositeNavigationRouter.shared.navigate(to: route)
             }
         } else {
             if WalletConnectManager.shared.canConnect(url: url) {

--- a/Multisig/UI/Safe Management/Create Safe/SafeDeployingViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/SafeDeployingViewController.swift
@@ -62,7 +62,7 @@ class SafeDeployingViewController: UIViewController {
         super.viewDidAppear(animated)
         animationView.play()
         if let safe = safe, safe.safeStatus == .deploymentFailed {
-            DefaultNavigationRouter.shared.navigateAfterDelay(to: NavigationRoute.deploymentFailed(safe: safe))
+            CompositeNavigationRouter.shared.navigateAfterDelay(to: NavigationRoute.deploymentFailed(safe: safe))
         }
     }
 

--- a/Multisig/UI/Safe Management/Create Safe/SafeDeploymentNotificationController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/SafeDeploymentNotificationController.swift
@@ -63,7 +63,7 @@ class SafeDeploymentNotificationController {
         let address: String = userInfo["safe"] as! String
         let chainId: String = userInfo["chainId"] as! String
         let route = NavigationRoute.showAssets(address, chainId: chainId)
-        DefaultNavigationRouter.shared.navigate(to: route)
+        CompositeNavigationRouter.shared.navigate(to: route)
     }
 }
 

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeFormUIModel.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeFormUIModel.swift
@@ -879,7 +879,7 @@ class CreateSafeFormUIModel {
         try? saveCreationParameters()
 
         App.shared.notificationHandler.safeAdded(address: address)
-        DefaultNavigationRouter.shared.navigate(to: NavigationRoute.showAssets(address.checksummed, chainId: chain.id))
+        CompositeNavigationRouter.shared.navigate(to: NavigationRoute.showAssets(address.checksummed, chainId: chain.id))
     }
 }
 

--- a/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
+++ b/Multisig/UI/Settings/AppSettingsViewController/AppSettingsViewController.swift
@@ -349,6 +349,10 @@ class AppSettingsViewController: UITableViewController {
 }
 
 extension AppSettingsViewController: NavigationRouter {
+    func routeFrom(from url: URL) -> NavigationRoute? {
+        nil
+    }
+    
     func canNavigate(to route: NavigationRoute) -> Bool {
         if route.path == NavigationRoute.connectToWeb().path {
             return true

--- a/MultisigTests/Logic/DefaultNavigationRouterTests.swift
+++ b/MultisigTests/Logic/DefaultNavigationRouterTests.swift
@@ -1,0 +1,185 @@
+//
+//  DefaultNavigationRouterTests.swift
+//  MultisigTests
+//
+//  Created by Dmitrii Bespalov on 21.08.23.
+//  Copyright © 2023 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+
+final class DefaultNavigationRouterTests: XCTestCase {
+
+    let router = DefaultNavigationRouter()
+
+    func testAssets() {
+        let url = "https://some.host/eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b/balances"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/assets/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+    }
+
+    func testHistory() {
+        let url = "https://some.host/eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b/transactions/history"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/transactions/history/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+    }
+    
+    func testQueue() {
+        let url = "https://some.host/eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b/transactions/queue"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/transactions/queued/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+    }
+
+    func testTransactionDetails() {
+        let url = "https://some.host/eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b/transactions/some_identifier"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/transactions/details/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+        XCTAssertEqual(route?.info["transactionId"] as? String, "some_identifier")
+    }
+    
+    func testNotMatching() {
+        let url = "https://some.host/settings"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertNil(route)
+    }
+    
+    func testAddressNotValid() {
+        let url = "https://some.host/eth:0x1111111111D19Be20952152c549ee478Bf1bf36b/balances"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertNil(route)
+    }
+    
+    func testChainIDNotValid() {
+        let url = "https://some.host/ABC:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b/balances"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertNil(route)
+    }
+}
+
+final class ExtendedNavigationRouterTests: XCTestCase {
+    let router = ExtendedNavigationRouter()
+
+    func testAssets() {
+        let url = "https://some.host/balances?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/assets/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+    }
+    
+    func testHistory() {
+        let url = "https://some.host/transactions/history?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/transactions/history/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+
+    }
+    
+    func testQueue() {
+        let url = "https://some.host/transactions/queue?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/transactions/queued/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+
+    }
+
+    func testDetails() {
+        let url = "https://some.host/transactions/tx?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b&id=some-identifier"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/transactions/details/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+        XCTAssertEqual(route?.info["transactionId"] as? String, "some-identifier")
+    }
+    
+}
+
+fileprivate let SUPPORTED_PATH = "/some/path"
+fileprivate let UNSUPPORTED_PATH = "/"
+
+final class CompositeNavigationRouterTests: XCTestCase {
+    class RouterA: NavigationRouter {
+        
+        func canNavigate(to route: NavigationRoute) -> Bool {
+            false
+        }
+        
+        var didNavigate = false
+        
+        func navigate(to route: NavigationRoute) {
+            didNavigate = true
+        }
+        
+        func routeFrom(from url: URL) -> NavigationRoute? {
+            nil
+        }
+    }
+
+    class RouterB: NavigationRouter {
+        func canNavigate(to route: NavigationRoute) -> Bool {
+            route.path == SUPPORTED_PATH
+        }
+        
+        var didNavigate = false
+        
+        func navigate(to route: NavigationRoute) {
+            didNavigate = true
+        }
+        
+        func routeFrom(from url: URL) -> NavigationRoute? {
+            NavigationRoute(path: SUPPORTED_PATH)
+        }
+    }
+    
+    var a: RouterA!
+    var b: RouterB!
+    var router: CompositeNavigationRouter!
+    
+    override func setUp() async throws {
+        a = RouterA()
+        b = RouterB()
+        router = CompositeNavigationRouter(routers: [a, b])
+    }
+
+    func testCanNavigate() {
+        XCTAssertFalse(router.canNavigate(to: NavigationRoute(path: UNSUPPORTED_PATH)))
+        XCTAssertTrue(router.canNavigate(to: NavigationRoute(path: SUPPORTED_PATH)))
+    }
+    
+    func testNavigateNotSupportedPath() {
+        router.navigate(to: NavigationRoute(path: UNSUPPORTED_PATH))
+        XCTAssertFalse(a.didNavigate)
+        XCTAssertFalse(b.didNavigate)
+    }
+    
+    func testNavigateSupportedpath() {
+        router.navigate(to: NavigationRoute(path: SUPPORTED_PATH))
+        XCTAssertFalse(a.didNavigate)
+        XCTAssertTrue(b.didNavigate)
+    }
+    
+    func testRouteFrom() {
+        let route = router.routeFrom(from: URL("https://some.host/"))
+        XCTAssertEqual(route?.path, SUPPORTED_PATH)
+    }
+}
+
+extension URL {
+    fileprivate init(_ str: String) {
+        guard let url = URL(string: str) else {
+            preconditionFailure("Failed to creat url: \(str)")
+        }
+        self = url
+    }
+}

--- a/MultisigTests/Logic/DefaultNavigationRouterTests.swift
+++ b/MultisigTests/Logic/DefaultNavigationRouterTests.swift
@@ -76,6 +76,14 @@ final class ExtendedNavigationRouterTests: XCTestCase {
         XCTAssertEqual(route?.info["chainId"] as? String, "1")
     }
     
+    func testCollectibles() {
+        let url = "https://some.host/balances/nfts?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/assets/collectibles/")
+        XCTAssertEqual(route?.info["address"] as? String, "0x46F228b5eFD19Be20952152c549ee478Bf1bf36b")
+        XCTAssertEqual(route?.info["chainId"] as? String, "1")
+    }
+    
     func testHistory() {
         let url = "https://some.host/transactions/history?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b"
         let route = router.routeFrom(from: URL(url))

--- a/MultisigTests/Logic/DefaultNavigationRouterTests.swift
+++ b/MultisigTests/Logic/DefaultNavigationRouterTests.swift
@@ -67,6 +67,18 @@ final class DefaultNavigationRouterTests: XCTestCase {
 
 final class ExtendedNavigationRouterTests: XCTestCase {
     let router = ExtendedNavigationRouter()
+    
+    func testWelcome() {
+        let url = "https://some.host/welcome"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/assets/")
+    }
+    
+    func testHome() {
+        let url = "https://some.host/home"
+        let route = router.routeFrom(from: URL(url))
+        XCTAssertEqual(route?.path, "/assets/")
+    }
 
     func testAssets() {
         let url = "https://some.host/balances?safe=eth:0x46F228b5eFD19Be20952152c549ee478Bf1bf36b"


### PR DESCRIPTION
Handles #3297 

Changes proposed in this pull request:
- Keep supporting previous format
- Added tests

Overall:
- [x] asset - balances
- [x] assets - nfts
- [x] transactions history
- [x] transaction queue
- [x] transaction details
- [ ] safe creation
- [ ] safe loading
- [ ] safe settings
- [ ] app settings, legal info