### PR TITLE
Gh 3332/UI issues fix

### DIFF
--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/AddKeyNavigationController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/AddKeyNavigationController.swift
@@ -14,6 +14,7 @@ class AddKeyNavigationController: UINavigationController, UINavigationController
     override func viewDidLoad() {
         super.viewDidLoad()
         self.delegate = self
+        view.backgroundColor = .systemBackground
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/AddOwnerKeyCell.xib
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/AddOwnerKeyCell.xib
@@ -12,42 +12,43 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="207" id="KGk-i7-Jjw" customClass="AddOwnerKeyCell" customModule="Multisig" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="506" height="207"/>
+            <rect key="frame" x="0.0" y="0.0" width="506" height="90"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="506" height="207"/>
+                <rect key="frame" x="0.0" y="0.0" width="506" height="90"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SSh-dA-uMb" customClass="StyledView" customModule="Multisig" customModuleProvider="target">
-                        <rect key="frame" x="10" y="4" width="486" height="199"/>
+                        <rect key="frame" x="10" y="4" width="486" height="72"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="border-normal" translatesAutoresizingMaskIntoConstraints="NO" id="xwT-Kw-q6X">
-                                <rect key="frame" x="2" y="2" width="482" height="195"/>
+                                <rect key="frame" x="2" y="2" width="482" height="68"/>
                                 <color key="tintColor" name="border"/>
                             </imageView>
-                            <stackView opaque="NO" contentMode="scaleToFill" misplaced="YES" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="jNX-QI-Bo2">
-                                <rect key="frame" x="20" y="20" width="458" height="187"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="jNX-QI-Bo2">
+                                <rect key="frame" x="14" y="6" width="458" height="60"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ico-add-key" translatesAutoresizingMaskIntoConstraints="NO" id="Iif-cN-8FF">
-                                        <rect key="frame" x="0.0" y="0.0" width="28" height="187"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="28" height="60"/>
                                         <constraints>
+                                            <constraint firstAttribute="height" constant="60" id="WIK-oZ-dgt"/>
                                             <constraint firstAttribute="width" constant="28" id="sfS-L2-XQi"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Import existing key" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KEp-67-AwD">
-                                        <rect key="frame" x="36" y="0.0" width="293" height="187"/>
+                                        <rect key="frame" x="36" y="0.0" width="293" height="60"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ico-wallet-logos" translatesAutoresizingMaskIntoConstraints="NO" id="mlo-a5-fV4">
-                                        <rect key="frame" x="337" y="0.0" width="85" height="187"/>
+                                        <rect key="frame" x="337" y="0.0" width="85" height="60"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="85" id="uox-Vn-gfh"/>
                                         </constraints>
                                     </imageView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrow" translatesAutoresizingMaskIntoConstraints="NO" id="5Uv-jN-oIS">
-                                        <rect key="frame" x="430" y="0.0" width="28" height="187"/>
+                                        <rect key="frame" x="430" y="0.0" width="28" height="60"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="28" id="z3d-aq-W8D"/>
                                         </constraints>

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/AddOwnerKeyViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/AddOwnerKeyViewController.swift
@@ -90,6 +90,8 @@ class AddOwnerKeyViewController: UITableViewController {
         title = "Add Owner Key"
         navigationItem.largeTitleDisplayMode = .always
         navigationController?.navigationBar.prefersLargeTitles = true
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: "Back")
+        
         ViewControllerFactory.removeNavigationBarBorder(self)
 
         if showsCloseButton {

--- a/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/ChooseHardwareWalletTableViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/AddOwnerKeyViewController/ChooseHardwareWalletTableViewController.swift
@@ -92,7 +92,6 @@ class ChooseHardwareWalletTableViewController: UITableViewController {
                 completion()
             }
             push(flow: ledgerKeyFlow)
-            return
 
         case .keystone:
             connectKeystoneFlow = ConnectKeystoneFlow { [unowned self] _ in
@@ -100,7 +99,6 @@ class ChooseHardwareWalletTableViewController: UITableViewController {
                 completion()
             }
             push(flow: connectKeystoneFlow)
-            return
         }
     }
 }

--- a/Multisig/UI/Settings/OwnerKeyManagement/SocialLoginKey/AddOwnerViaSocialViewController.swift
+++ b/Multisig/UI/Settings/OwnerKeyManagement/SocialLoginKey/AddOwnerViaSocialViewController.swift
@@ -20,14 +20,13 @@ class AddOwnerViaSocialViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = "Create or import with Google or Apple ID"
-        navigationItem.largeTitleDisplayMode = .always
-        navigationController?.navigationBar.prefersLargeTitles = true
-
+        title = "Continue with…"
+        
+        ViewControllerFactory.removeNavigationBarBorder(self)
+        
         appleButton.setText("Continue with Apple ID", .filled)
         googleButton.setText("Continue with Google", .filled)
         titleLabel.setStyle(.body)
-        ViewControllerFactory.makeMultiLinesNavigationBar(self)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/Multisig/UI/Settings/OwnerKeyManagement/SocialLoginKey/AddOwnerViaSocialViewController.xib
+++ b/Multisig/UI/Settings/OwnerKeyManagement/SocialLoginKey/AddOwnerViaSocialViewController.xib
@@ -14,71 +14,70 @@
             <connections>
                 <outlet property="appleButton" destination="6Pb-Es-tsr" id="UxL-UX-WLn"/>
                 <outlet property="googleButton" destination="WjK-dY-8RY" id="yKT-aJ-cwa"/>
-                <outlet property="titleLabel" destination="EeW-nC-Cni" id="Qjh-8C-Qxd"/>
+                <outlet property="titleLabel" destination="hVR-6x-MFT" id="IIX-V8-Oub"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create a new owner key or sign in, if you have already created one before." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EeW-nC-Cni">
-                    <rect key="frame" x="16" y="75" width="343" height="40.666666666666657"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="4uL-t0-pPu">
-                    <rect key="frame" x="16" y="489" width="343" height="128"/>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Pdk-Ee-dsO">
+                    <rect key="frame" x="16" y="89" width="361" height="713"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WjK-dY-8RY">
-                            <rect key="frame" x="0.0" y="0.0" width="343" height="56"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="56" id="fPj-f8-sBV"/>
-                            </constraints>
-                            <color key="tintColor" name="backgroundPrimary"/>
-                            <inset key="imageEdgeInsets" minX="-20" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <state key="normal" title="Continue with Google" image="ico-google">
-                                <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="googleButtonTouched:" destination="-1" eventType="touchUpInside" id="Uqa-Rb-Wcz"/>
-                            </connections>
-                        </button>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Pb-Es-tsr">
-                            <rect key="frame" x="0.0" y="72" width="343" height="56"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="56" id="fjV-9W-u3M"/>
-                            </constraints>
-                            <color key="tintColor" name="backgroundPrimary"/>
-                            <inset key="imageEdgeInsets" minX="-20" minY="0.0" maxX="0.0" maxY="0.0"/>
-                            <state key="normal" title="Continue with Apple ID" image="ico-apple">
-                                <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <connections>
-                                <action selector="appleButtonTouched:" destination="-1" eventType="touchUpInside" id="y9B-1A-pJN"/>
-                            </connections>
-                        </button>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create a new owner key or sign in, if you have already created one before." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hVR-6x-MFT">
+                            <rect key="frame" x="0.0" y="0.0" width="361" height="40.666666666666664"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" image="ico-social-keys" translatesAutoresizingMaskIntoConstraints="NO" id="nkc-x5-4UK">
+                            <rect key="frame" x="0.0" y="70.666666666666657" width="361" height="484.33333333333337"/>
+                        </imageView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="4uL-t0-pPu">
+                            <rect key="frame" x="0.0" y="585" width="361" height="128"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WjK-dY-8RY">
+                                    <rect key="frame" x="0.0" y="0.0" width="361" height="56"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="56" id="fPj-f8-sBV"/>
+                                    </constraints>
+                                    <color key="tintColor" name="backgroundPrimary"/>
+                                    <inset key="imageEdgeInsets" minX="-20" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    <state key="normal" title="Continue with Google" image="ico-google">
+                                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="googleButtonTouched:" destination="-1" eventType="touchUpInside" id="Uqa-Rb-Wcz"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Pb-Es-tsr">
+                                    <rect key="frame" x="0.0" y="72" width="361" height="56"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="56" id="fjV-9W-u3M"/>
+                                    </constraints>
+                                    <color key="tintColor" name="backgroundPrimary"/>
+                                    <inset key="imageEdgeInsets" minX="-20" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                    <state key="normal" title="Continue with Apple ID" image="ico-apple">
+                                        <color key="titleColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="appleButtonTouched:" destination="-1" eventType="touchUpInside" id="y9B-1A-pJN"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
                     </subviews>
                 </stackView>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ico-social-keys" translatesAutoresizingMaskIntoConstraints="NO" id="nkc-x5-4UK">
-                    <rect key="frame" x="16" y="145.66666666666663" width="343" height="300"/>
-                </imageView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="nkc-x5-4UK" secondAttribute="trailing" constant="16" id="3BP-3D-Bez"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="4uL-t0-pPu" secondAttribute="bottom" constant="16" id="3Tj-hf-tnX"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="EeW-nC-Cni" secondAttribute="trailing" constant="16" id="6Gc-Eb-qYT"/>
-                <constraint firstItem="nkc-x5-4UK" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="9ab-Ac-dK5"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="4uL-t0-pPu" secondAttribute="trailing" constant="16" id="9ko-pz-nbx"/>
-                <constraint firstItem="4uL-t0-pPu" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="GAC-aO-ioe"/>
-                <constraint firstItem="4uL-t0-pPu" firstAttribute="top" relation="greaterThanOrEqual" secondItem="nkc-x5-4UK" secondAttribute="bottom" constant="20" id="L7O-lI-eP8"/>
-                <constraint firstItem="EeW-nC-Cni" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="16" id="Qw7-Ci-SKv"/>
-                <constraint firstItem="EeW-nC-Cni" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="c58-Po-MDP"/>
-                <constraint firstItem="nkc-x5-4UK" firstAttribute="top" secondItem="EeW-nC-Cni" secondAttribute="bottom" constant="30" id="luB-OP-e1K"/>
+                <constraint firstItem="Pdk-Ee-dsO" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="16" id="JML-LD-AAw"/>
+                <constraint firstAttribute="trailing" secondItem="Pdk-Ee-dsO" secondAttribute="trailing" constant="16" id="JTr-OC-3ZA"/>
+                <constraint firstItem="Pdk-Ee-dsO" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="30" id="rPY-cK-cta"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Pdk-Ee-dsO" secondAttribute="bottom" constant="16" id="vHK-4B-fSx"/>
             </constraints>
             <point key="canvasLocation" x="73" y="10"/>
         </view>

--- a/Multisig/UI/Settings/OwnerKeyManagement/SocialLoginKey/CreatingSocialKeyViewController.xib
+++ b/Multisig/UI/Settings/OwnerKeyManagement/SocialLoginKey/CreatingSocialKeyViewController.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -21,17 +22,21 @@
             <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nvc-Tf-Geo" customClass="LottieAnimationView" customModule="Lottie">
-                    <rect key="frame" x="76" y="254" width="240" height="128"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Nvc-Tf-Geo" customClass="LottieAnimationView" customModule="Lottie">
+                    <rect key="frame" x="146.66666666666666" y="328.66666666666669" width="100" height="100"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="100" id="m2o-ze-4hB"/>
+                        <constraint firstAttribute="width" constant="100" id="r4c-2N-fbI"/>
+                    </constraints>
                 </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Creating your owner key..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="94Z-s9-QHK">
-                    <rect key="frame" x="16" y="449" width="300" height="58"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Creating your owner key..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="94Z-s9-QHK">
+                    <rect key="frame" x="25" y="448.66666666666669" width="343" height="20.333333333333314"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="343" id="U2g-XG-2hR"/>
                     </constraints>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
+                    <color key="textColor" name="labelPrimary"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
@@ -47,6 +52,9 @@
         </view>
     </objects>
     <resources>
+        <namedColor name="labelPrimary">
+            <color red="0.070588235294117646" green="0.074509803921568626" blue="0.070588235294117646" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>


### PR DESCRIPTION
Handles #3332

Changes proposed in this pull request:
- Added "back" text to the back button
- removed a line under the title
- removed the text jumping when you switch to the "Create or import with" screen - to do that, renamed title to "Continue with..."
- fixed the _top of the owner keys list is displayed for a few sec on the "creating your key" screen_
- set animation size to be 100x100 on the "creating your key" screen (as per figma)