### PR TITLE
GH-3344 added warning and deprecation mechanism

### DIFF
--- a/Multisig/App/NSNotification+Events.swift
+++ b/Multisig/App/NSNotification+Events.swift
@@ -79,4 +79,6 @@ extension NSNotification.Name {
     // MARK: - Chain settings changed
 
     static let chainSettingsChanged = NSNotification.Name("io.gnosis.safe.chainSettingsChanged")
+    
+    static let didReadConnectToWebBanner = NSNotification.Name("global.safe.ios.didReadConnectToWebBanner")
 }

--- a/Multisig/Cross-layer/FirebaseRemoteConfig.swift
+++ b/Multisig/Cross-layer/FirebaseRemoteConfig.swift
@@ -17,13 +17,15 @@ class FirebaseRemoteConfig {
         case deprecated
         case safeClaimEnabled
         case crashDebugEnabled
+        case connectToWebDiscontinued
     }
 
     private var remoteConfig: RemoteConfig
     private let defaultValues: [String : NSObject] = [Key.newestVersion.rawValue : "" as NSObject,
                                                       Key.deprecatedSoon.rawValue : "" as NSObject,
                                                       Key.deprecated.rawValue : "" as NSObject,
-                                                      Key.safeClaimEnabled.rawValue : false as NSObject]
+                                                      Key.safeClaimEnabled.rawValue : false as NSObject,
+                                                      Key.connectToWebDiscontinued.rawValue : false as NSObject]
     private init() {
         remoteConfig = RemoteConfig.remoteConfig()
         let settings = RemoteConfigSettings()

--- a/Multisig/Logic/Models/AppSettings.swift
+++ b/Multisig/Logic/Models/AppSettings.swift
@@ -70,6 +70,13 @@ extension AppSettings {
 
     @UserDefault(key: "io.gnosis.multisig.relayBannerWasShown")
     static var relayBannerWasShown: Bool?
+    
+    @UserDefault(key: "global.safe.ios.connectToWebDeprecationMessageShown")
+    static var didShowDeprecateConnectToWeb: Bool? {
+        didSet {
+            NotificationCenter.default.post(name: .didReadConnectToWebBanner, object: nil)
+        }
+    }
 
     @AppSetting(\.lastMarketingVersion)
     static var lastMarketingVersion: String?

--- a/Multisig/UI/App/MainTabBarViewController.swift
+++ b/Multisig/UI/App/MainTabBarViewController.swift
@@ -261,6 +261,7 @@ class MainTabBarViewController: UITabBarController {
         let nav = SettingsUINavigationController(rootViewController: root)
         let tabItem = UITabBarItem(title: title, image: image, tag: tag)
         nav.tabBarItem = tabItem
+        nav.showBadge()
         return nav
     }
 
@@ -584,16 +585,24 @@ class SettingsUINavigationController: UINavigationController {
             selector: #selector(showBadge),
             name: NSNotification.Name.IntercomUnreadConversationCountDidChange,
             object: nil)
-
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showBadge),
+            name: NSNotification.Name.didReadConnectToWebBanner,
+            object: nil)
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
+    var shouldShowBadge: Bool {
+        IntercomConfig.unreadConversationCount() > 0 ||
+            AppSettingsViewController.shouldBringAttentionToDesktopPairing()
+    }
+    
     @objc func showBadge() {
-        let count = IntercomConfig.unreadConversationCount()
-        if count > 0 {
+        if shouldShowBadge {
             tabBarItem.badgeValue = ""
             tabBarItem.badgeColor = UIColor.warning
         } else {

--- a/Multisig/UI/Dapps/DappsViewController.swift
+++ b/Multisig/UI/Dapps/DappsViewController.swift
@@ -281,7 +281,7 @@ class DappsViewController: UIViewController, UITableViewDataSource, UITableViewD
 
 extension DappsViewController: QRCodeScannerViewControllerDelegate {
     func scannerViewControllerDidScan(_ url: String) {
-        if (url.starts(with: "safe-wc:")) {
+        if (url.starts(with: "safe-wc:")) && FirebaseRemoteConfig.shared.boolValue(key: .connectToWebDiscontinued) != true {
             dismiss(animated: true) {
                 let route = NavigationRoute.connectToWeb(url)
                 CompositeNavigationRouter.shared.navigate(to: route)


### PR DESCRIPTION
Handles #3344

Changes proposed in this pull request:
- Deprecation warning inside the "Connect to web" screen
- Badge that is opened when there are keys and the banner not seen yet
- Support for Firebase remote config parameter to disable the feature

