### PR TITLE
Gh 2886/warning in transactions

### DIFF
--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -1029,6 +1029,13 @@
 		B367AED22B0CB89600F06B86 /* TransactionValidationTestCase1.json in Resources */ = {isa = PBXBuildFile; fileRef = B367AED12B0CB89600F06B86 /* TransactionValidationTestCase1.json */; };
 		B3710B3D2AD584BE002E503B /* SecureConfig in Frameworks */ = {isa = PBXBuildFile; productRef = B3710B3C2AD584BE002E503B /* SecureConfig */; };
 		B3710B442AD5AAD7002E503B /* config.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B3710B432AD5AAD7002E503B /* config.bundle */; };
+		B380756B2B0CF45200C62BCF /* TransactionValidationTestCase_InvalidSafeTxHash.json in Resources */ = {isa = PBXBuildFile; fileRef = B380756A2B0CF45200C62BCF /* TransactionValidationTestCase_InvalidSafeTxHash.json */; };
+		B380756D2B0CF60A00C62BCF /* TransactionValidationTestCase_NoConfirmations.json in Resources */ = {isa = PBXBuildFile; fileRef = B380756C2B0CF60A00C62BCF /* TransactionValidationTestCase_NoConfirmations.json */; };
+		B380756F2B0CF6AC00C62BCF /* TransactionValidationTestCase_ConfirmationsNotFromOwners.json in Resources */ = {isa = PBXBuildFile; fileRef = B380756E2B0CF6AC00C62BCF /* TransactionValidationTestCase_ConfirmationsNotFromOwners.json */; };
+		B38075712B0CF75200C62BCF /* TransactionValidationTestCase_SignerNotMatchingSignature.json in Resources */ = {isa = PBXBuildFile; fileRef = B38075702B0CF75200C62BCF /* TransactionValidationTestCase_SignerNotMatchingSignature.json */; };
+		B38075732B0CF7C600C62BCF /* TransactionValidationTestCase_MultipleConfirmations.json in Resources */ = {isa = PBXBuildFile; fileRef = B38075722B0CF7C600C62BCF /* TransactionValidationTestCase_MultipleConfirmations.json */; };
+		B38075752B0CF85900C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json in Resources */ = {isa = PBXBuildFile; fileRef = B38075742B0CF85900C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json */; };
+		B38075772B0CFD3A00C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json in Resources */ = {isa = PBXBuildFile; fileRef = B38075762B0CFD3A00C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json */; };
 		B3B6044F2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B6044E2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift */; };
 		B3C4D2D92AAF596D0026A8BC /* UIViewController+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C4D2D82AAF596D0026A8BC /* UIViewController+Navigation.swift */; };
 		D80B5A032769CEAD00D6E024 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80B5A022769CEAD00D6E024 /* Tooltip.swift */; };
@@ -2089,6 +2096,13 @@
 		B3710B432AD5AAD7002E503B /* config.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = config.bundle; sourceTree = "<group>"; };
 		B3710B452AD5AE9D002E503B /* apis-prod.example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "apis-prod.example.json"; sourceTree = "<group>"; };
 		B3710B462AD5AE9D002E503B /* apis-staging.example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "apis-staging.example.json"; sourceTree = "<group>"; };
+		B380756A2B0CF45200C62BCF /* TransactionValidationTestCase_InvalidSafeTxHash.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TransactionValidationTestCase_InvalidSafeTxHash.json; sourceTree = "<group>"; };
+		B380756C2B0CF60A00C62BCF /* TransactionValidationTestCase_NoConfirmations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TransactionValidationTestCase_NoConfirmations.json; sourceTree = "<group>"; };
+		B380756E2B0CF6AC00C62BCF /* TransactionValidationTestCase_ConfirmationsNotFromOwners.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TransactionValidationTestCase_ConfirmationsNotFromOwners.json; sourceTree = "<group>"; };
+		B38075702B0CF75200C62BCF /* TransactionValidationTestCase_SignerNotMatchingSignature.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TransactionValidationTestCase_SignerNotMatchingSignature.json; sourceTree = "<group>"; };
+		B38075722B0CF7C600C62BCF /* TransactionValidationTestCase_MultipleConfirmations.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TransactionValidationTestCase_MultipleConfirmations.json; sourceTree = "<group>"; };
+		B38075742B0CF85900C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json; sourceTree = "<group>"; };
+		B38075762B0CFD3A00C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json; sourceTree = "<group>"; };
 		B3B6044E2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertControllerStyle+Multiplatform.swift"; sourceTree = "<group>"; };
 		B3C4D2D82AAF596D0026A8BC /* UIViewController+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Navigation.swift"; sourceTree = "<group>"; };
 		D80B5A022769CEAD00D6E024 /* Tooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tooltip.swift; sourceTree = "<group>"; };
@@ -3482,6 +3496,13 @@
 				0A64313F247ED1AA006FD30A /* MultisigIntegrationTests.xctestplan */,
 				B367AECE2B0CB59700F06B86 /* TransactionValidationTests.swift */,
 				B367AED12B0CB89600F06B86 /* TransactionValidationTestCase1.json */,
+				B38075762B0CFD3A00C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json */,
+				B38075742B0CF85900C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json */,
+				B38075722B0CF7C600C62BCF /* TransactionValidationTestCase_MultipleConfirmations.json */,
+				B380756C2B0CF60A00C62BCF /* TransactionValidationTestCase_NoConfirmations.json */,
+				B38075702B0CF75200C62BCF /* TransactionValidationTestCase_SignerNotMatchingSignature.json */,
+				B380756E2B0CF6AC00C62BCF /* TransactionValidationTestCase_ConfirmationsNotFromOwners.json */,
+				B380756A2B0CF45200C62BCF /* TransactionValidationTestCase_InvalidSafeTxHash.json */,
 				0A802B8F24E581A50001790F /* SafeClientGatewayServiceIntegrationTests.swift */,
 				0A513A9C2768EBC900F07D5A /* DelegateKeyTests.swift */,
 				5532D4D02449A1E40067505A /* MockLogger.swift */,
@@ -5220,11 +5241,18 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B38075732B0CF7C600C62BCF /* TransactionValidationTestCase_MultipleConfirmations.json in Resources */,
+				B38075772B0CFD3A00C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json in Resources */,
+				B38075752B0CF85900C62BCF /* TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json in Resources */,
 				0AA5F55F28BF6F2200D6D220 /* claiming_test_fixtures.yml in Resources */,
+				B380756B2B0CF45200C62BCF /* TransactionValidationTestCase_InvalidSafeTxHash.json in Resources */,
+				B380756D2B0CF60A00C62BCF /* TransactionValidationTestCase_NoConfirmations.json in Resources */,
 				0A61E8452670E632009D68A4 /* __Snapshots__ in Resources */,
 				6A91EFDA27DA2C8D009E63E9 /* wc_registry_wallets.json in Resources */,
 				0AA5F55D28BF667000D6D220 /* claiming_test_fixtures.json in Resources */,
+				B380756F2B0CF6AC00C62BCF /* TransactionValidationTestCase_ConfirmationsNotFromOwners.json in Resources */,
 				B367AED22B0CB89600F06B86 /* TransactionValidationTestCase1.json in Resources */,
+				B38075712B0CF75200C62BCF /* TransactionValidationTestCase_SignerNotMatchingSignature.json in Resources */,
 				0A74719A269F152D008E9F2D /* chains_4_safes_0x1230B3d59858296A31053C1b8562Ecf89A2f888b_balances_usd.json in Resources */,
 				0A3DFEFE2667D3A700B45770 /* README.md in Resources */,
 			);

--- a/Multisig.xcodeproj/project.pbxproj
+++ b/Multisig.xcodeproj/project.pbxproj
@@ -274,7 +274,6 @@
 		04FEFE8128C6304B0028A349 /* TokenDistributionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 04FEFE7F28C6304B0028A349 /* TokenDistributionViewController.xib */; };
 		0A007124254B255C00A57CAF /* UIFont+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A007123254B255C00A57CAF /* UIFont+Styles.swift */; };
 		0A00712A254B379000A57CAF /* UIColor+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A007129254B379000A57CAF /* UIColor+Styles.swift */; };
-		0A01DCE42770B0A100A87D7A /* TransactionIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A01DCE32770B0A100A87D7A /* TransactionIntegrationTests.swift */; };
 		0A0391CB27C565D4003C871A /* IconButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A0391C727C565D3003C871A /* IconButtonTableViewCell.xib */; };
 		0A0391CC27C565D4003C871A /* HelpTextTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0391C827C565D3003C871A /* HelpTextTableViewCell.swift */; };
 		0A0391CD27C565D4003C871A /* HelpTextTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A0391C927C565D3003C871A /* HelpTextTableViewCell.xib */; };
@@ -1026,6 +1025,8 @@
 		B32620492A961E690003A2F0 /* AddSafeFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B32620482A961E690003A2F0 /* AddSafeFlow.swift */; };
 		B343BEB32A77DDA1006BF46B /* DMSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0491067C28F99246005A4A99 /* DMSans-Bold.ttf */; };
 		B35BFD0F2A937DC000A9FB15 /* NavigationRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35BFD0E2A937DC000A9FB15 /* NavigationRouterTests.swift */; };
+		B367AED02B0CB69200F06B86 /* TransactionValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B367AECE2B0CB59700F06B86 /* TransactionValidationTests.swift */; };
+		B367AED22B0CB89600F06B86 /* TransactionValidationTestCase1.json in Resources */ = {isa = PBXBuildFile; fileRef = B367AED12B0CB89600F06B86 /* TransactionValidationTestCase1.json */; };
 		B3710B3D2AD584BE002E503B /* SecureConfig in Frameworks */ = {isa = PBXBuildFile; productRef = B3710B3C2AD584BE002E503B /* SecureConfig */; };
 		B3710B442AD5AAD7002E503B /* config.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B3710B432AD5AAD7002E503B /* config.bundle */; };
 		B3B6044F2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3B6044E2A850F5E007BDAC0 /* UIAlertControllerStyle+Multiplatform.swift */; };
@@ -2082,6 +2083,8 @@
 		B300E8CA2AF3A7A90073A908 /* SafeNoncesRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeNoncesRequest.swift; sourceTree = "<group>"; };
 		B32620482A961E690003A2F0 /* AddSafeFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSafeFlow.swift; sourceTree = "<group>"; };
 		B35BFD0E2A937DC000A9FB15 /* NavigationRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouterTests.swift; sourceTree = "<group>"; };
+		B367AECE2B0CB59700F06B86 /* TransactionValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionValidationTests.swift; sourceTree = "<group>"; };
+		B367AED12B0CB89600F06B86 /* TransactionValidationTestCase1.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TransactionValidationTestCase1.json; sourceTree = "<group>"; };
 		B3710B3B2AD58492002E503B /* SecureConfig */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SecureConfig; path = Packages/SecureConfig; sourceTree = "<group>"; };
 		B3710B432AD5AAD7002E503B /* config.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = config.bundle; sourceTree = "<group>"; };
 		B3710B452AD5AE9D002E503B /* apis-prod.example.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "apis-prod.example.json"; sourceTree = "<group>"; };
@@ -3477,6 +3480,8 @@
 				6A91EFD827DA2C45009E63E9 /* Data */,
 				0A3DFF002667D7DA00B45770 /* CoreData */,
 				0A64313F247ED1AA006FD30A /* MultisigIntegrationTests.xctestplan */,
+				B367AECE2B0CB59700F06B86 /* TransactionValidationTests.swift */,
+				B367AED12B0CB89600F06B86 /* TransactionValidationTestCase1.json */,
 				0A802B8F24E581A50001790F /* SafeClientGatewayServiceIntegrationTests.swift */,
 				0A513A9C2768EBC900F07D5A /* DelegateKeyTests.swift */,
 				5532D4D02449A1E40067505A /* MockLogger.swift */,
@@ -5219,6 +5224,7 @@
 				0A61E8452670E632009D68A4 /* __Snapshots__ in Resources */,
 				6A91EFDA27DA2C8D009E63E9 /* wc_registry_wallets.json in Resources */,
 				0AA5F55D28BF667000D6D220 /* claiming_test_fixtures.json in Resources */,
+				B367AED22B0CB89600F06B86 /* TransactionValidationTestCase1.json in Resources */,
 				0A74719A269F152D008E9F2D /* chains_4_safes_0x1230B3d59858296A31053C1b8562Ecf89A2f888b_balances_usd.json in Resources */,
 				0A3DFEFE2667D3A700B45770 /* README.md in Resources */,
 			);
@@ -5996,13 +6002,13 @@
 				0A9BC35F246058F800EB9C5D /* MockLogger.swift in Sources */,
 				550A6182268A23A9002C02E1 /* SafeNetworkMigrationTests.swift in Sources */,
 				0A7B3518288071EB00EC04EC /* TestCoreDataStack.swift in Sources */,
-				0A01DCE42770B0A100A87D7A /* TransactionIntegrationTests.swift in Sources */,
 				0A65522B28816B9900701238 /* TestingAppDelegate.swift in Sources */,
 				0A61E83E2670DED5009D68A4 /* BalanceTableViewCellTests.swift in Sources */,
 				0A3DFEF72667D1C000B45770 /* CoreDataTestCase.swift in Sources */,
 				0A06532F27B68AF40008C5F1 /* WebConnectionRepositoryTests.swift in Sources */,
 				0A6552282881642300701238 /* UIIntegrationTestCase.swift in Sources */,
 				0A802B9024E581A50001790F /* SafeClientGatewayServiceIntegrationTests.swift in Sources */,
+				B367AED02B0CB69200F06B86 /* TransactionValidationTests.swift in Sources */,
 				0AC62ED628783700007945A1 /* CreatePasscodeFlowTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Multisig.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -384,8 +384,8 @@
         "repositoryURL": "https://github.com/WalletConnect/WalletConnectSwiftV2",
         "state": {
           "branch": null,
-          "revision": "7cf45ea8f98097b5813cd3c99d08b87c1be28ebe",
-          "version": "1.9.5"
+          "revision": "4aa4c8229077c133730e361d0d7a17f9e56bdffd",
+          "version": "1.9.6"
         }
       },
       {

--- a/Multisig/Logic/Models/Transaction.swift
+++ b/Multisig/Logic/Models/Transaction.swift
@@ -251,7 +251,7 @@ extension Transaction {
         .reduce(Data()) { $0 + $1 }
     }
 
-    private func safeTransactionHash() -> HashString? {
+    func safeTransactionHash() -> HashString? {
         let data = encodeTransactionData()
         return try? HashString(hex: EthHasher.hash(data).toHexString())
     }

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
@@ -453,7 +453,7 @@ class TransactionDetailCellBuilder {
         }
         
         guard !txMultisigInfo.confirmations.isEmpty else {
-            throw "Transaction has no confirmations. This may be a dangerous transaction"
+            throw "Transaction has no confirmations."
         }
         
         // all confirming addresses are from safe owners

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
@@ -59,7 +59,7 @@ class TransactionDetailCellBuilder {
         let isCreationTx = buildCreationTx(tx)
         if !isCreationTx {
             buildHeader(tx)
-            buildWarning(tx, safe)
+            // buildWarning(tx, safe)
             buildAssetContract(tx)
             buildStatus(tx)
             buildMultisigInfo(tx)

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
@@ -10,6 +10,9 @@ import Foundation
 import UIKit
 import SwiftCryptoTokenFormatter
 import SwiftUI
+import Version
+import Solidity
+import SafeWeb3
 
 class TransactionDetailCellBuilder {
 
@@ -43,18 +46,20 @@ class TransactionDetailCellBuilder {
         tableView.registerCell(DetailTransferInfoCell.self)
         tableView.registerCell(DetailRejectionInfoCell.self)
         tableView.registerCell(DetailStatusCell.self)
+        tableView.registerCell(WarningTableViewCell.self)
     }
 
-    func build(_ tx: SCGModels.TransactionDetails) -> [UITableViewCell] {
+    func build(_ tx: SCGModels.TransactionDetails, _ safe: Safe?) -> [UITableViewCell] {
         result = []
-        buildTransaction(tx)
+        buildTransaction(tx, safe)
         return result
     }
 
-    func buildTransaction(_ tx: SCGModels.TransactionDetails) {
+    func buildTransaction(_ tx: SCGModels.TransactionDetails, _ safe: Safe? = nil) {
         let isCreationTx = buildCreationTx(tx)
         if !isCreationTx {
             buildHeader(tx)
+            buildWarning(tx, safe)
             buildAssetContract(tx)
             buildStatus(tx)
             buildMultisigInfo(tx)
@@ -426,6 +431,139 @@ class TransactionDetailCellBuilder {
             label: label,
             addressLogoUri: addressLogoUri,
             isOutgoing: isOutgoing)
+    }
+    
+    // TODO: Move this out into a class or function and Unit-Test it and / or Integration Test it.
+    func buildWarning(_ tx: SCGModels.TransactionDetails, _ safe: Safe? = nil) {
+        guard tx.txStatus.isAwatingConfiramtions || tx.txStatus == .awaitingExecution else {
+            // don't warn outside of signature or execution requests
+            return
+        }
+        
+        // safe has owners
+        guard let safe = safe, let ownersInfo = safe.ownersInfo, !ownersInfo.isEmpty else {
+            // not enough data for further checks
+            return
+        }
+        let ownerAddresses = ownersInfo.map(\.address)
+        
+        // transaction has confirmations
+        guard let txMultisigInfo = tx.multisigInfo else {
+            // not a kind of transaction we can take a look into
+            return
+        }
+        
+        guard !txMultisigInfo.confirmations.isEmpty else {
+            warningCell("Warning: transaction has no confirmations. This may be a dangerous transaction")
+            return
+        }
+        
+        // all confirming addresses are from safe owners
+        guard txMultisigInfo.confirmations.allSatisfy({ confirmation in
+            ownerAddresses.contains(confirmation.signer.value.address)
+        }) else {
+            warningCell("Warning: not all confirmations are from safe owners.")
+            return
+        }
+        
+        // transaction hash is valid
+        guard var transaction = Transaction(tx: tx),
+              let contractVersion = safe.version.flatMap(Version.init),
+              let chainId = safe.chain?.id
+        else {
+            // not enough information for further checks
+            return
+        }
+        transaction.safe = AddressString(stringLiteral: safe.displayAddress)
+        transaction.safeVersion = contractVersion
+        transaction.chainId = chainId
+        
+        guard
+            let computedSafeTxHash = transaction.safeTransactionHash(),
+            transaction.safeTxHash == computedSafeTxHash
+        else {
+            warningCell("Warning: safeTxHash is invalid. This may be a dangerous transaction.")
+            return
+        }
+        
+        // all confirming signatures are from a confirming addresses
+        func signer(of signature: Data) -> Address? {
+            guard signature.count >= 65 else {
+                // cannot decode signature
+                return nil
+            }
+            
+            let v: UInt8 = signature[0]
+            let r: Data /* 32 bytes */ = signature[1...32]
+            let s: Data /* 32 bytes */ = signature[33...64]
+            
+            let contractSignature: UInt8 = 0
+            let approvedHashSignature: UInt8 = 1
+            let ethSignSignature: ClosedRange<UInt8> = (31...UInt8.max)
+            
+            if contractVersion >= Version(1, 1, 0) {
+                switch v {
+                case contractSignature, approvedHashSignature:
+                    let owner = (try? Sol.Address(data: r)).map { Address($0) }
+                    return owner
+                    
+                case ethSignSignature:
+                    let hash = computedSafeTxHash.hash
+                    let message = "\u{19}Ethereum Signed Message:\n\(hash.count)".data(using: .utf8)! + hash
+                    
+                    let pubKey = try? EthereumPublicKey(
+                        message: message.makeBytes(),
+                        v: EthereumQuantity(quantity: (BigUInt(v) - 4) - 27),
+                        r: EthereumQuantity(r.makeBytes()),
+                        s: EthereumQuantity(s.makeBytes())
+                    )
+
+                    let owner = pubKey.map(\.address).map(Address.init)
+                    return owner
+                    
+                default:
+                    let pubKey = try? EthereumPublicKey(
+                        message: computedSafeTxHash.hash.makeBytes(),
+                        v: EthereumQuantity(quantity: BigUInt(v)),
+                        r: EthereumQuantity(r.makeBytes()),
+                        s: EthereumQuantity(s.makeBytes())
+                    )
+                    let owner = pubKey.map(\.address).map(Address.init)
+                    return owner
+                }
+            } else {
+                switch v {
+                case contractSignature, approvedHashSignature:
+                    let owner = (try? Sol.Address(data: r)).map { Address($0) }
+                    return owner
+                default:
+                    let pubKey = try? EthereumPublicKey(
+                        message: computedSafeTxHash.hash.makeBytes(),
+                        v: EthereumQuantity(quantity: BigUInt(v)),
+                        r: EthereumQuantity(r.makeBytes()),
+                        s: EthereumQuantity(s.makeBytes())
+                    )
+                    let owner = pubKey.map(\.address).map(Address.init)
+                    return owner
+
+                }
+            }
+        }
+        
+        guard txMultisigInfo.confirmations.allSatisfy({ confirmation in
+            signer(of: confirmation.signature.data) == confirmation.signer.value.address
+        }) else {
+            warningCell("Warning: not all signatures are from safe's owners.")
+            return
+        }
+        
+        // all good! no warnings.
+    }
+    
+    func warningCell(_ text: String) {
+        let cell = newCell(WarningTableViewCell.self)
+        cell.set(title: text)
+        result.append(cell)
     }
 
 

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
@@ -511,7 +511,7 @@ class TransactionDetailsViewController: LoadableViewController, UITableViewDataS
         self.tx = transformer.transformed(transaction: self.tx!)
 
         trackScreen()
-        cells = builder.build(self.tx!, safe)
+        cells = builder.build(self.tx!)
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
@@ -511,7 +511,7 @@ class TransactionDetailsViewController: LoadableViewController, UITableViewDataS
         self.tx = transformer.transformed(transaction: self.tx!)
 
         trackScreen()
-        cells = builder.build(self.tx!)
+        cells = builder.build(self.tx!, safe)
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/MultisigIntegrationTests/TransactionIntegrationTests.swift
+++ b/MultisigIntegrationTests/TransactionIntegrationTests.swift
@@ -161,7 +161,7 @@ class TransactionIntegrationTests: XCTestCase {
         continueAfterFailure = false
         let privateKey = try PrivateKey(data: Data(hex: "0xe7979e5f2ceb1d4ef76019d1fdba88b50ceefe0575bbfdf94969837c50a5d895"))
 
-        let input = ERC20.transfer(
+        let callData = ERC20.transfer(
             // eoa address
 //            to: "Ad302A4b09402b41EC3Fb4981B63E4Dd141fed6d",
             // safe address
@@ -170,7 +170,7 @@ class TransactionIntegrationTests: XCTestCase {
             value: 1000
         ).encode()
 
-        print("call data", input.toHexStringWithPrefix())
+        print("call data", callData.toHexStringWithPrefix())
 
         let minerTip = Eth.Amount(value: 2, unit: Eth.Unit.gigawei).converted(to: Eth.Unit.wei).value
 
@@ -180,7 +180,7 @@ class TransactionIntegrationTests: XCTestCase {
             // erc20 contract address (LOVE)
             to: "b3a4Bc89d8517E0e2C9B66703d09D3029ffa1e6d",
             // erc20 transfer call
-            input: Sol.Bytes(storage: input),
+            input: Sol.Bytes(storage: callData),
             fee: Eth.Fee1559(
                 maxFeePerGas: minerTip,
                 maxPriorityFee: minerTip
@@ -405,7 +405,7 @@ class TransactionIntegrationTests: XCTestCase {
             confirmation.signature.data
         }.joined()
 
-        let input = try GnosisSafe_v1_3_0.execTransaction(
+        let callData = try GnosisSafe_v1_3_0.execTransaction(
             to:  Sol.Address(txData.to.value.data32),
             value: Sol.UInt256(txData.value.data32),
             data: Sol.Bytes(storage: txData.hexData?.data ?? Data()),
@@ -419,7 +419,7 @@ class TransactionIntegrationTests: XCTestCase {
             signatures: Sol.Bytes(storage: Data(signatures))
         ).encode()
 
-        print("call data", input.toHexStringWithPrefix())
+        print("call data", callData.toHexStringWithPrefix())
 
         let minerTip = Eth.Amount(value: 2, unit: Eth.Unit.gigawei).converted(to: Eth.Unit.wei).value
 
@@ -427,7 +427,7 @@ class TransactionIntegrationTests: XCTestCase {
             chainId: 4,
             from: "728cafe9fB8CC2218Fb12a9A2D9335193caa07e0",
             to: "dd1D27C114aB45e8A650B251eDFA1b0795bbe020",
-            input: Sol.Bytes(storage: input),
+            input: Sol.Bytes(storage: callData),
             fee: Eth.Fee1559(
                 maxFeePerGas: minerTip,
                 maxPriorityFee: minerTip

--- a/MultisigIntegrationTests/TransactionValidationTestCase1.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase1.json
@@ -1,0 +1,219 @@
+{
+    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.1"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x7dec7a1c46320f9bc4b62fe22e6ad34fe1f54b08c39637d064d104def4f3c812591ad2da837f5d9049d74e038811f76fcb33ac739e7ef866f696abdc9e55e1f51b",
+              "submittedAt": 1614014118798
+            }
+          ],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json
@@ -1,0 +1,242 @@
+{
+    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          },
+          {
+              "value": "0x728cafe9fB8CC2218Fb12a9A2D9335193caa07e0",
+              "name": null,
+              "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.0.0",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.0.0",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.0.0"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x7dec7a1c46320f9bc4b62fe22e6ad34fe1f54b08c39637d064d104def4f3c812591ad2da837f5d9049d74e038811f76fcb33ac739e7ef866f696abdc9e55e1f51b",
+              "submittedAt": 1614014118798
+            },
+            {
+              "signer": {
+                "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x0000000000000000000000009f87c1acaf3afc6a5557c58284d9f8609470b571abababababababababababababababababababababababababababababababab00",
+              "submittedAt": 1614014118797
+            },
+            {
+              "signer": {
+                "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x0000000000000000000000009f7dfab2222a473284205cddf08a677726d786a0abababababababababababababababababababababababababababababababab01",
+              "submittedAt": 1614014118797
+            },
+          ],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_0_0.json
@@ -1,5 +1,5 @@
 {
-    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "testCaseName": "All valid signatures for v1.0.0",
     "chain": {
         "chainId": "1",
         "chainName": "Ethereum",

--- a/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json
@@ -1,0 +1,251 @@
+{
+    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          },
+          {
+              "value": "0x728cafe9fB8CC2218Fb12a9A2D9335193caa07e0",
+              "name": null,
+              "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.0",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.0",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.0"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x7dec7a1c46320f9bc4b62fe22e6ad34fe1f54b08c39637d064d104def4f3c812591ad2da837f5d9049d74e038811f76fcb33ac739e7ef866f696abdc9e55e1f51b",
+              "submittedAt": 1614014118798
+            },
+            {
+              "signer": {
+                "value": "0x728cafe9fB8CC2218Fb12a9A2D9335193caa07e0",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x8828432c415e8f6ea6fe37148d178aa37664d0e635954e6d32de7123ec49d4450164cc128094144e59d88bbb94242bbd9e3a4a90bcd6cc3b858eeb40a953ca7c20",
+              "submittedAt": 1614014118797
+            },
+            {
+              "signer": {
+                "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x0000000000000000000000009f87c1acaf3afc6a5557c58284d9f8609470b571abababababababababababababababababababababababababababababababab00",
+              "submittedAt": 1614014118797
+            },
+            {
+              "signer": {
+                "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x0000000000000000000000009f7dfab2222a473284205cddf08a677726d786a0abababababababababababababababababababababababababababababababab01",
+              "submittedAt": 1614014118797
+            },
+          ],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_AllSignatureTypes_v1_1_0.json
@@ -1,5 +1,5 @@
 {
-    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "testCaseName": "All valid signatures for v1.1.0 and above",
     "chain": {
         "chainId": "1",
         "chainName": "Ethereum",

--- a/MultisigIntegrationTests/TransactionValidationTestCase_ConfirmationsNotFromOwners.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_ConfirmationsNotFromOwners.json
@@ -1,0 +1,214 @@
+{
+    "testCaseName": "Transaction confirmation signer is not in safe owners",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.1"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x7dec7a1c46320f9bc4b62fe22e6ad34fe1f54b08c39637d064d104def4f3c812591ad2da837f5d9049d74e038811f76fcb33ac739e7ef866f696abdc9e55e1f51b",
+              "submittedAt": 1614014118798
+            }
+          ],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_InvalidSafeTxHash.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_InvalidSafeTxHash.json
@@ -1,0 +1,219 @@
+{
+    "testCaseName": "Invalid safeTxHash",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.1"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xffff4190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x7dec7a1c46320f9bc4b62fe22e6ad34fe1f54b08c39637d064d104def4f3c812591ad2da837f5d9049d74e038811f76fcb33ac739e7ef866f696abdc9e55e1f51b",
+              "submittedAt": 1614014118798
+            }
+          ],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_MultipleConfirmations.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_MultipleConfirmations.json
@@ -1,0 +1,265 @@
+{
+    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.1"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xa6de2e7c697f0bd469fa1d9e24f4d955a6ba013eecc770a63781aa3698c9abe5",
+        "executedAt": 1694994827000,
+        "txStatus": "FAILED",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
+            "name": "Safe: MultiSend 1.1.1",
+            "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x8D29bE29923b68abfDD21e541b9374737B49cdAD.png"
+          },
+          "dataSize": "164",
+          "value": "0",
+          "methodName": "multiSend",
+          "actionCount": 1,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": "0x8d80ff0a00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000059004ddc2d193948926d02f9b1fe9e1daa0718270ed5000000000000000000000000000000000000000000000000016345785d8a000000000000000000000000000000000000000000000000000000000000000000041249c58b00000000000000",
+          "dataDecoded": {
+            "method": "multiSend",
+            "parameters": [
+              {
+                "name": "transactions",
+                "type": "bytes",
+                "value": "0x004ddc2d193948926d02f9b1fe9e1daa0718270ed5000000000000000000000000000000000000000000000000016345785d8a000000000000000000000000000000000000000000000000000000000000000000041249c58b",
+                "valueDecoded": [
+                  {
+                    "operation": 0,
+                    "to": "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+                    "value": "100000000000000000",
+                    "data": "0x1249c58b",
+                    "dataDecoded": {
+                      "method": "mint",
+                      "parameters": []
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "to": {
+            "value": "0x8D29bE29923b68abfDD21e541b9374737B49cdAD",
+            "name": "Safe: MultiSend 1.1.1",
+            "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x8D29bE29923b68abfDD21e541b9374737B49cdAD.png"
+          },
+          "value": "0",
+          "operation": 1,
+          "trustedDelegateCallTarget": true,
+          "addressInfoIndex": {
+            "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5": {
+              "value": "0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5",
+              "name": "Compound Ether",
+              "logoUri": "https://safe-transaction-assets.safe.global/tokens/logos/0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5.png"
+            }
+          }
+        },
+        "txHash": "0x0444a2bf7b7d77dd3de5b1fd2a082e06e3f0e23aafe3e199b941596e6daaceb1",
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1607940967582,
+          "nonce": 19,
+          "safeTxGas": "135275",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xa6de2e7c697f0bd469fa1d9e24f4d955a6ba013eecc770a63781aa3698c9abe5",
+          "executor": {
+            "value": "0x357274B8fE85c7696106fC4a8E4D26A53981bAcc",
+            "name": null,
+            "logoUri": null
+          },
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x16cf24cddee1d9b947cc330a57daa5b83c64bfa3b26faf5bfff7c281f2bf8a5558016b5878ce3d7df04339f089e9e444642ec0ee13c2b1482150d37e80e58fdf1c",
+              "submittedAt": 1607940967600
+            },
+            {
+              "signer": {
+                "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x3ac535045d56e25d318e8a70f7bd1b26224fd11089c3ff41552f633547b86705764e110f7c889ca9322784846377cd3a986ee9253bdfd2737238ad1a60a1142e1c",
+              "submittedAt": 1616371316036
+            }
+          ],
+          "rejectors": [
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_MultipleConfirmations.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_MultipleConfirmations.json
@@ -1,5 +1,5 @@
 {
-    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "testCaseName": "Multiple valid confirmations",
     "chain": {
         "chainId": "1",
         "chainName": "Ethereum",

--- a/MultisigIntegrationTests/TransactionValidationTestCase_NoConfirmations.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_NoConfirmations.json
@@ -1,0 +1,209 @@
+{
+    "testCaseName": "Transaction has no confirmations",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.1"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTestCase_SignerNotMatchingSignature.json
+++ b/MultisigIntegrationTests/TransactionValidationTestCase_SignerNotMatchingSignature.json
@@ -1,0 +1,219 @@
+{
+    "testCaseName": "Valid transaction, Ethereum, 2/4 owners, 1/2 confirmations",
+    "chain": {
+        "chainId": "1",
+        "chainName": "Ethereum",
+        "description": "The main Ethereum network",
+        "l2": false,
+        "nativeCurrency": {
+          "name": "Ether",
+          "symbol": "ETH",
+          "decimals": 18,
+          "logoUri": "https://safe-transaction-assets.safe.global/chains/1/currency_logo.png"
+        },
+        "transactionService": "https://safe-transaction-mainnet.safe.global",
+        "blockExplorerUriTemplate": {
+          "address": "https://etherscan.io/address/{{address}}",
+          "txHash": "https://etherscan.io/tx/{{txHash}}",
+          "api": "https://api.etherscan.io/api?module={{module}}&action={{action}}&address={{address}}&apiKey={{apiKey}}"
+        },
+        "disabledWallets": [
+          "NONE",
+          "opera",
+          "operaTouch",
+          "safeMobile",
+          "socialSigner",
+          "tally",
+          "trust",
+          "walletConnect"
+        ],
+        "ensRegistryAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+        "features": [
+          "CONTRACT_INTERACTION",
+          "DEFAULT_TOKENLIST",
+          "DOMAIN_LOOKUP",
+          "EIP1271",
+          "EIP1559",
+          "ERC721",
+          "MOONPAY_MOBILE",
+          "NATIVE_WALLETCONNECT",
+          "PUSH_NOTIFICATIONS",
+          "RISK_MITIGATION",
+          "SAFE_APPS",
+          "SAFE_TX_GAS_OPTIONAL",
+          "SOCIAL_LOGIN",
+          "SPENDING_LIMIT",
+          "TX_SIMULATION"
+        ],
+        "gasPrice": [
+          {
+            "type": "oracle",
+            "uri": "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=JNFAU892RF9TJWBU3EV7DJCPIWZY8KEMY1",
+            "gasParameter": "FastGasPrice",
+            "gweiFactor": "1000000000.000000000"
+          }
+        ],
+        "publicRpcUri": {
+          "authentication": "NO_AUTHENTICATION",
+          "value": "https://cloudflare-eth.com"
+        },
+        "rpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "safeAppsRpcUri": {
+          "authentication": "API_KEY_PATH",
+          "value": "https://mainnet.infura.io/v3/"
+        },
+        "shortName": "eth",
+        "theme": {
+          "textColor": "#001428",
+          "backgroundColor": "#DDDDDD"
+        }
+      },
+    "safe": {
+        "address": {
+          "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+          "name": null,
+          "logoUri": null
+        },
+        "chainId": "1",
+        "nonce": 20,
+        "threshold": 2,
+        "owners": [
+          {
+            "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+            "name": null,
+            "logoUri": null
+          },
+          {
+            "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "implementation": {
+          "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+          "name": "Safe 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F.png"
+        },
+        "implementationVersionState": "OUTDATED",
+        "collectiblesTag": "1663062476",
+        "txQueuedTag": "1670938242",
+        "txHistoryTag": "1697840747",
+        "messagesTag": "1700560947",
+        "modules": [
+          {
+            "value": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
+            "name": null,
+            "logoUri": null
+          }
+        ],
+        "fallbackHandler": {
+          "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+          "name": "Safe: DefaultCallbackHandler 1.1.1",
+          "logoUri": "https://safe-transaction-assets.safe.global/contracts/logos/0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44.png"
+        },
+        "guard": null,
+        "version": "1.1.1"
+      },
+    "tx": {
+        "safeAddress": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+        "txId": "multisig_0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7_0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+        "executedAt": null,
+        "txStatus": "AWAITING_CONFIRMATIONS",
+        "txInfo": {
+          "type": "Custom",
+          "humanDescription": null,
+          "richDecodedInfo": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "dataSize": "0",
+          "value": "0",
+          "methodName": null,
+          "actionCount": null,
+          "isCancellation": false
+        },
+        "txData": {
+          "hexData": null,
+          "dataDecoded": null,
+          "to": {
+            "value": "0xfF501B324DC6d78dC9F983f140B9211c3EdB4dc7",
+            "name": null,
+            "logoUri": null
+          },
+          "value": "0",
+          "operation": 0,
+          "trustedDelegateCallTarget": null,
+          "addressInfoIndex": null
+        },
+        "txHash": null,
+        "detailedExecutionInfo": {
+          "type": "MULTISIG",
+          "submittedAt": 1614014118782,
+          "nonce": 20,
+          "safeTxGas": "43808",
+          "baseGas": "0",
+          "gasPrice": "0",
+          "gasToken": "0x0000000000000000000000000000000000000000",
+          "refundReceiver": {
+            "value": "0x0000000000000000000000000000000000000000",
+            "name": null,
+            "logoUri": null
+          },
+          "safeTxHash": "0xaed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127",
+          "executor": null,
+          "signers": [
+            {
+              "value": "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x8712128BEA09C9687Df05A5D692F3750F8086C81",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x80F59C1D46EFC1Bb18F0AaEc132b77266f00Be9a",
+              "name": null,
+              "logoUri": null
+            },
+            {
+              "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+              "name": null,
+              "logoUri": null
+            }
+          ],
+          "confirmationsRequired": 2,
+          "confirmations": [
+            {
+              "signer": {
+                "value": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+                "name": null,
+                "logoUri": null
+              },
+              "signature": "0x7dec7a1c46320f9bc4b62fe22e6ad34fe1f54b08c39637d064d104def4f3c812591ad2da837f5d9049d74e038811f76fcb33ac739e7ef866f696abdc9e55e1f51b",
+              "submittedAt": 1614014118798
+            }
+          ],
+          "rejectors": [],
+          "gasTokenInfo": null,
+          "trusted": true
+        },
+        "safeAppInfo": null
+      }
+}

--- a/MultisigIntegrationTests/TransactionValidationTests.swift
+++ b/MultisigIntegrationTests/TransactionValidationTests.swift
@@ -117,7 +117,7 @@ final class TransactionValidationTests: CoreDataTestCase {
         try builder.validate(tx: testCase.tx, safe: safe)
     }
     
-    func testSigning() throws {
+    func testGenerateEthSignSignature() throws {
         let key = try PrivateKey(data:  Data(hex: "0xe7979e5f2ceb1d4ef76019d1fdba88b50ceefe0575bbfdf94969837c50a5d895"))
         //
         let messageHash: Data = Data(hex: "aed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127")
@@ -144,8 +144,8 @@ final class TransactionValidationTests: CoreDataTestCase {
         print(address) // 0x728cafe9fB8CC2218Fb12a9A2D9335193caa07e0
     }
     
-    func testSome() {
-        // contract signature
+    func testGenerateFakeSignatureData() {
+        // type 'contract signature' (0)
         let s = Data(repeating: 0xab, count: 32)
         
         let addr1: Sol.Address = "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571"
@@ -154,7 +154,7 @@ final class TransactionValidationTests: CoreDataTestCase {
         
         print(data1.toHexStringWithPrefix())
         
-        // approvedHash
+        // type 'approved hash' (1)
         let addr2: Sol.Address = "0x9F7dfAb2222A473284205cdDF08a677726d786A0"
         let data2 = addr2.encode() + s + Data([1])
         print(data2.toHexStringWithPrefix())

--- a/MultisigIntegrationTests/TransactionValidationTests.swift
+++ b/MultisigIntegrationTests/TransactionValidationTests.swift
@@ -1,0 +1,98 @@
+//
+//  TransactionValidationTests.swift
+//  MultisigTests
+//
+//  Created by Dmitrii Bespalov on 21.11.23.
+//  Copyright © 2023 Gnosis Ltd. All rights reserved.
+//
+
+import XCTest
+@testable import Multisig
+import SafeWeb3
+
+final class TransactionValidationTests: CoreDataTestCase {
+    
+    struct TestCase: Decodable {
+        var chain: SCGModels.Chain
+        var safe: SCGModels.SafeInfoExtended
+        var tx: SCGModels.TransactionDetails
+        
+        init(chain: SCGModels.Chain, safe: SCGModels.SafeInfoExtended, tx: SCGModels.TransactionDetails) {
+            self.chain = chain
+            self.safe = safe
+            self.tx = tx
+        }
+        
+        init?(named name: String, extension ext: String = "json") {
+            let bundle = Bundle(for: TransactionValidationTests.self)
+            guard let url = bundle.url(forResource: name, withExtension: ext) else { return nil }
+            let jsonDecoder = JSONDecoder()
+            do {
+                let data = try Data(contentsOf: url)
+                self = try jsonDecoder.decode(TestCase.self, from: data)
+            } catch {
+                print("[TestCase] Failed to load: \(error)")
+                return nil
+            }
+        }
+    }
+    
+    
+    // test cases
+    
+    // prereqs:
+    // status == awaiting
+    // safe.owners.count > 0
+    // safe.version is there
+    // safe.chain.id is there
+    // can convert tx to Transaction
+    // tx has multisig info
+    
+    // safeTxHash is correctly computed from properties -> invalid safeTxHash!
+    // confirmations.count == 0 -> no confirmations!
+    // confirmations not subset of owners -> not owners!
+    // one confirmation - must be a valid confirmation -> not owner!
+    // multiple confirmations - all must be valid confirmations, i.e. match the address -> not owner!
+        // just one invalid -> warning
+        // all invalid -> warning
+    // types for contract version >= 1.1.0
+        // confirmation type = contract signature
+        // confirmation type = approvedHash
+        // confirmation type = eth_sign
+        // confirmation type = ecdsa
+    // types for contract version 1.1.0
+        // confirmation type = contract signature
+        // confirmation type = approvedHash
+        // confirmation type = ecdsa
+    
+    func testTransactions() throws {
+        try validateTransactionCase("TransactionValidationTestCase1")
+    }
+    
+    func validateTransactionCase(_ testCaseName: String) throws {
+        guard let testCase = TestCase(named: testCaseName) else {
+            XCTFail("Failed to load test case")
+            return
+        }
+        
+        let chain = try Chain.create(testCase.chain)
+        let safe = Safe.create(
+            address: testCase.safe.address.value.description,
+            version: testCase.safe.version,
+            name: "Test",
+            chain: chain
+        )
+        safe.update(from: testCase.safe)
+        
+        let vc = UIViewController()
+        let tableView = UITableView()
+        vc.view.addSubview(tableView)
+        
+        let builder = TransactionDetailCellBuilder(vc: vc, tableView: tableView, chain: chain)
+        
+        XCTAssertNoThrow(
+            try builder.validate(tx: testCase.tx, safe: safe)
+        )
+    }
+    
+}

--- a/MultisigIntegrationTests/TransactionValidationTests.swift
+++ b/MultisigIntegrationTests/TransactionValidationTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Multisig
 import SafeWeb3
+import Solidity
 
 final class TransactionValidationTests: CoreDataTestCase {
     
@@ -37,36 +38,59 @@ final class TransactionValidationTests: CoreDataTestCase {
         }
     }
     
-    
-    // test cases
-    
-    // prereqs:
-    // status == awaiting
-    // safe.owners.count > 0
-    // safe.version is there
-    // safe.chain.id is there
-    // can convert tx to Transaction
-    // tx has multisig info
-    
-    // safeTxHash is correctly computed from properties -> invalid safeTxHash!
-    // confirmations.count == 0 -> no confirmations!
-    // confirmations not subset of owners -> not owners!
-    // one confirmation - must be a valid confirmation -> not owner!
-    // multiple confirmations - all must be valid confirmations, i.e. match the address -> not owner!
-        // just one invalid -> warning
-        // all invalid -> warning
-    // types for contract version >= 1.1.0
-        // confirmation type = contract signature
-        // confirmation type = approvedHash
-        // confirmation type = eth_sign
-        // confirmation type = ecdsa
-    // types for contract version 1.1.0
-        // confirmation type = contract signature
-        // confirmation type = approvedHash
-        // confirmation type = ecdsa
-    
     func testTransactions() throws {
-        try validateTransactionCase("TransactionValidationTestCase1")
+        // Happy Cases
+        
+        XCTAssertNoThrow(
+            try validateTransactionCase("TransactionValidationTestCase1")
+        )
+        
+        XCTAssertNoThrow(
+            try validateTransactionCase("TransactionValidationTestCase_MultipleConfirmations")
+        )
+        
+        
+        XCTAssertNoThrow(
+            try validateTransactionCase("TransactionValidationTestCase_AllSignatureTypes_v1_1_0")
+        )
+        
+        XCTAssertNoThrow(
+            try validateTransactionCase("TransactionValidationTestCase_AllSignatureTypes_v1_0_0")
+        )
+        
+        // Invalid Cases
+        
+        XCTAssertThrowsError(
+            try validateTransactionCase("TransactionValidationTestCase_InvalidSafeTxHash"),
+            "expected 'Invalid safeTxHash' error",
+            { e in
+                XCTAssertEqual(e.localizedDescription, "Invalid safeTxHash. This may be a dangerous transaction.")
+            }
+        )
+        
+        XCTAssertThrowsError(
+            try validateTransactionCase("TransactionValidationTestCase_NoConfirmations"),
+            "expected 'No confirmations' error",
+            { e in
+                XCTAssertEqual(e.localizedDescription, "Transaction has no confirmations.")
+            }
+        )
+        
+        XCTAssertThrowsError(
+            try validateTransactionCase("TransactionValidationTestCase_ConfirmationsNotFromOwners"),
+            "expected 'Confirmations not from owners' error",
+            { e in
+                XCTAssertEqual(e.localizedDescription, "Not all confirmations are from safe owners.")
+            }
+        )
+
+        XCTAssertThrowsError(
+            try validateTransactionCase("TransactionValidationTestCase_SignerNotMatchingSignature"),
+            "expected 'Signature' error",
+            { e in
+                XCTAssertEqual(e.localizedDescription, "Not all signatures are from safe's owners. This may be a dangerous transaction.")
+            }
+        )
     }
     
     func validateTransactionCase(_ testCaseName: String) throws {
@@ -90,9 +114,49 @@ final class TransactionValidationTests: CoreDataTestCase {
         
         let builder = TransactionDetailCellBuilder(vc: vc, tableView: tableView, chain: chain)
         
-        XCTAssertNoThrow(
-            try builder.validate(tx: testCase.tx, safe: safe)
-        )
+        try builder.validate(tx: testCase.tx, safe: safe)
     }
     
+    func testSigning() throws {
+        let key = try PrivateKey(data:  Data(hex: "0xe7979e5f2ceb1d4ef76019d1fdba88b50ceefe0575bbfdf94969837c50a5d895"))
+        //
+        let messageHash: Data = Data(hex: "aed54190962dce2c448391841fcd7730eb23ac18c5fa2a7896ac9074bf38f127")
+
+        let preimagePrefix = "\u{19}Ethereum Signed Message:\n\(messageHash.count)"
+
+        let preimage = preimagePrefix.data(using: .utf8)! + messageHash
+        
+        var signature = try key.sign(hash: EthHasher.hash(preimage))
+        // make it safe signature encoding
+        signature.v += 4
+        
+        print(signature.hexadecimal)
+        // 0x8828432c415e8f6ea6fe37148d178aa37664d0e635954e6d32de7123ec49d4450164cc128094144e59d88bbb94242bbd9e3a4a90bcd6cc3b858eeb40a953ca7c20
+        
+        let pubKey = try EthereumPublicKey(
+            message: preimage.makeBytes(),
+            v: EthereumQuantity(quantity: BigUInt(signature.v) - 27 - 4),
+            r: EthereumQuantity(signature.r.makeBytes()),
+            s: EthereumQuantity(signature.s.makeBytes())
+        )
+        
+        let address = pubKey.address.hex(eip55: true)
+        print(address) // 0x728cafe9fB8CC2218Fb12a9A2D9335193caa07e0
+    }
+    
+    func testSome() {
+        // contract signature
+        let s = Data(repeating: 0xab, count: 32)
+        
+        let addr1: Sol.Address = "0x9F87C1aCaF3Afc6a5557c58284D9F8609470b571"
+        
+        let data1 = addr1.encode() + s + Data([0])
+        
+        print(data1.toHexStringWithPrefix())
+        
+        // approvedHash
+        let addr2: Sol.Address = "0x9F7dfAb2222A473284205cdDF08a677726d786A0"
+        let data2 = addr2.encode() + s + Data([1])
+        print(data2.toHexStringWithPrefix())
+    }
 }

--- a/MultisigTests/Logic/Models/SignerTests.swift
+++ b/MultisigTests/Logic/Models/SignerTests.swift
@@ -56,7 +56,4 @@ class SignerTests: XCTestCase {
 
         XCTAssertEqual(pubKey.address.hex(eip55: true), "0xe44F9E113Fbd671Bf697d5a1cf1716E1a8c3F35b")
     }
-    
 }
-
-

--- a/MultisigTests/Logic/Models/SignerTests.swift
+++ b/MultisigTests/Logic/Models/SignerTests.swift
@@ -56,6 +56,7 @@ class SignerTests: XCTestCase {
 
         XCTAssertEqual(pubKey.address.hex(eip55: true), "0xe44F9E113Fbd671Bf697d5a1cf1716E1a8c3F35b")
     }
+    
 }
 
 


### PR DESCRIPTION
Handles #2886

Changes proposed in this pull request:
- Shows warning in the transaction details if:
  - transaction is awaiting signatures or execution AND
  - ( transaction has no confirmations OR
  - confirming addresses are not safe owners OR
  - confirming addresses do not match recovered addresses from confirmation signatures )
