### PR TITLE
GH-3327 un-use time zone adjustment in the queue

### DIFF
--- a/Multisig/UI/Transaction/TransactionListViewController/QueuedTransactionsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionListViewController/QueuedTransactionsViewController.swift
@@ -54,7 +54,7 @@ class QueuedTransactionsViewController: TransactionListViewController {
     }
 
     override func formatted(date: Date) -> String {
-        date.timeAgo(adjustForTimeZone: true)
+        date.timeAgo()
     }
 
     override func shouldHighlight(transaction: SCGModels.TxSummary) -> Bool {


### PR DESCRIPTION
Handles #3327

Changes proposed in this pull request:
- Removes time adjustment for the transactions in the queue list.
