### PR TITLE
GH-3415 add owner from owner keys; GH-3416 add address to address book.

### DIFF
--- a/Multisig/App/NSNotification+Events.swift
+++ b/Multisig/App/NSNotification+Events.swift
@@ -24,6 +24,7 @@ extension NSNotification.Name {
     static let ownerKeyRemoved = NSNotification.Name("io.gnosis.safe.ownerKeyRemoved")
     static let ownerKeyUpdated = NSNotification.Name("io.gnosis.safe.ownerKeyUpdated")
     static let ownerKeyBackedUp = NSNotification.Name("io.gnosis.safe.ownerKeyBackedUp")
+    static let ownerKeyListUpdated = NSNotification.Name("io.gnosis.safe.ownerKeyListUpdated")
     
     static let balanceLoading = NSNotification.Name("io.gnosis.safe.balanceLoading")
     static let balanceUpdated = NSNotification.Name("io.gnosis.safe.balanceUpdated")

--- a/Multisig/Features/Connect to Web/UI/Connection Request/WebConnectionRequestViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Connection Request/WebConnectionRequestViewController.swift
@@ -136,7 +136,7 @@ class WebConnectionRequestViewController: WebConnectionContainerViewController, 
 
         let keys = connectionController.accountKeys()
         chooseOwnerKeyVC = ChooseOwnerKeyViewController(
-                owners: keys,
+                owners: { keys} ,
                 chainID: String(connection.chainId!),
                 header: .none,
                 requestsPasscode: false,

--- a/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
+++ b/Multisig/Features/Connect to Web/UI/Details/WebConnectionDetailsViewController.swift
@@ -294,7 +294,7 @@ class WebConnectionDetailsViewController: UITableViewController, WebConnectionOb
     func changeAccount() {
         let keys = WebConnectionController.shared.accountKeys()
         let accountVC = ChooseOwnerKeyViewController(
-            owners: keys,
+            owners: { keys },
             chainID: chain.id,
             titleText: "Change owner key",
             header: .none,

--- a/Multisig/Logic/OwnerKeyController.swift
+++ b/Multisig/Logic/OwnerKeyController.swift
@@ -51,7 +51,7 @@ class OwnerKeyController {
                 break
             }
 
-            NotificationCenter.default.post(name: .ownerKeyImported, object: nil)
+            postNotification(.ownerKeyImported)
             return true
         } catch {
             App.shared.snackbar.show(error: GSError.error(description: "Could not import signing key.", error: error))
@@ -85,7 +85,7 @@ class OwnerKeyController {
                 break
             }
 
-            NotificationCenter.default.post(name: .ownerKeyImported, object: nil)
+            postNotification(.ownerKeyImported)
             return true
         } catch {
             App.shared.snackbar.show(error: GSError.error(description: "Could not import signing key.", error: error))
@@ -101,7 +101,7 @@ class OwnerKeyController {
             guard newKey != nil else { return false }
 
             Tracker.setNumKeys(KeyInfo.count(.walletConnect), type: .walletConnect)
-            NotificationCenter.default.post(name: .ownerKeyImported, object: nil)
+            postNotification(.ownerKeyImported)
 
             let name = wallet?.name ?? connection.remotePeer?.name ?? "unknown"
             Tracker.trackEvent(.connectInstalledWallet, parameters: ["wallet": name])
@@ -125,7 +125,7 @@ class OwnerKeyController {
             guard updatedKey != nil else { return false }
 
             Tracker.setNumKeys(KeyInfo.count(.walletConnect), type: .walletConnect)
-            NotificationCenter.default.post(name: .ownerKeyUpdated, object: nil)
+            postNotification(.ownerKeyUpdated)
 
             let name = wallet?.name ?? connection.remotePeer?.name ?? "unknown"
             Tracker.trackEvent(.connectInstalledWallet, parameters: ["wallet": name])
@@ -148,7 +148,7 @@ class OwnerKeyController {
         do {
             try KeyInfo.import(ledgerDeviceUUID: ledgerDeviceUUID, path: path, address: address, name: name)
             Tracker.setNumKeys(KeyInfo.count(.ledgerNanoX), type: .ledgerNanoX)
-            NotificationCenter.default.post(name: .ownerKeyImported, object: nil)
+            postNotification(.ownerKeyImported)
             Tracker.trackEvent(.ledgerKeyImported)
             return true
         } catch {
@@ -171,7 +171,7 @@ class OwnerKeyController {
             Tracker.setNumKeys(KeyInfo.count(.keystone), type: .keystone)
             Tracker.trackEvent(.keystoneKeyImported)
 
-            NotificationCenter.default.post(name: .ownerKeyImported, object: nil)
+            postNotification(.ownerKeyImported)
             return true
         } catch {
             App.shared.snackbar.show(error: GSError.error(description: "Failed to add Keystone owner", error: error))
@@ -190,7 +190,7 @@ class OwnerKeyController {
                     App.shared.snackbar.show(message: "Owner key removed from this app")
                     Tracker.trackEvent(.ownerKeyRemoved)
                     Tracker.setNumKeys(KeyInfo.count(keyInfo.keyType), type: keyInfo.keyType)
-                    NotificationCenter.default.post(name: .ownerKeyRemoved, object: nil)
+                    postNotification(.ownerKeyRemoved)
                 } else {
                     App.shared.snackbar.show(error: GSError.error(description: "Failed to remove imported key"))
                 }
@@ -204,7 +204,7 @@ class OwnerKeyController {
     static func edit(keyInfo: KeyInfo, name: String) {
         keyInfo.rename(newName: name)
         App.shared.snackbar.show(message: "Owner key updated")
-        NotificationCenter.default.post(name: .ownerKeyUpdated, object: nil)
+        postNotification(.ownerKeyUpdated)
     }
 
     static var hasPrivateKey: Bool {
@@ -322,6 +322,11 @@ class OwnerKeyController {
         Tracker.setNumKeys(KeyInfo.count(.keystone), type: .keystone)
         Tracker.setNumKeys(KeyInfo.count(.web3AuthApple), type: .web3AuthApple)
         Tracker.setNumKeys(KeyInfo.count(.web3AuthGoogle), type: .web3AuthGoogle)
-        NotificationCenter.default.post(name: .ownerKeyRemoved, object: nil)
+        postNotification(.ownerKeyRemoved)
+    }
+    
+    private static func postNotification(_ name: Notification.Name) {
+        NotificationCenter.default.post(name: name, object: nil)
+        NotificationCenter.default.post(name: .ownerKeyListUpdated, object: nil)
     }
 }

--- a/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
+++ b/Multisig/UI/Safe Management/Create Safe/Setup Safe/CreateSafeViewController.swift
@@ -334,7 +334,7 @@ class CreateSafeViewController: UIViewController, UITableViewDelegate, UITableVi
         }
 
         let keyPickerVC = ChooseOwnerKeyViewController(
-            owners: keys,
+            owners:  { keys },
             chainID: uiModel.chain.id,
             titleText: "Deployer Account",
             header: .text(description: "The selected account will be used to deploy the Safe."),

--- a/Multisig/UI/Settings/AddressBook/CreateAddressBookEntryViewController.swift
+++ b/Multisig/UI/Settings/AddressBook/CreateAddressBookEntryViewController.swift
@@ -15,6 +15,12 @@ class CreateAddressBookEntryViewController: UIViewController {
 
     var completion: ((Address, String) -> Void)?
     var chain: SCGModels.Chain!
+    var inputAddress: Address?
+    var inputName: String?
+    
+    var actionName: String = "Add"
+    var screenTitle: String = "New Entry"
+    var canEditAddress: Bool = true
 
     lazy var trackingParameters: [String: Any]  = { ["chain_id" : chain.id] }()
     private var debounceTimer: Timer!
@@ -26,16 +32,24 @@ class CreateAddressBookEntryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        
         assert(chain != nil, "Developer error: expect to have a chain")
         
-        navigationItem.title = "New Entry"
+        if let name = inputName {
+            textField.text = name
+        }
+        
+        navigationItem.title = screenTitle
+        
+        if let address = inputAddress {
+            addressField.setAddress(address, prefix: chain.shortName)
+        }
 
         addressField.setPlaceholderText("Enter entry address")
 
         addressField.onTap = { [weak self] in self?.didTapAddressField() }
 
-        nextButton = UIBarButtonItem(title: "Add", style: .done, target: self, action: #selector(didTapNextButton(_:)))
+        nextButton = UIBarButtonItem(title: actionName, style: .done, target: self, action: #selector(didTapNextButton(_:)))
         nextButton.isEnabled = false
 
         navigationItem.rightBarButtonItem = nextButton
@@ -56,6 +70,8 @@ class CreateAddressBookEntryViewController: UIViewController {
     }
 
     private func didTapAddressField() {
+        guard canEditAddress else { return }
+
         let alertVC = UIAlertController(title: nil, message: nil, preferredStyle: .multiplatformActionSheet)
 
         alertVC.addAction(UIAlertAction(title: "Paste from Clipboard", style: .default, handler: { [weak self] _ in

--- a/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionViewController.swift
+++ b/Multisig/UI/Transaction/ExecuteTransaction/ReviewExecutionViewController.swift
@@ -174,7 +174,7 @@ class ReviewExecutionViewController: ContainerViewController, PasscodeProtecting
         }
 
         let keyPickerVC = ChooseOwnerKeyViewController(
-            owners: keys,
+            owners: { keys },
             chainID: controller.chainId,
             titleText: "Select an execution key",
             header: .text(description: "The selected key will be used to execute this transaction."),

--- a/Multisig/UI/Transaction/InitiateTransaction/ReviewSafeTransactionViewController/ReviewSafeTransactionViewController.swift
+++ b/Multisig/UI/Transaction/InitiateTransaction/ReviewSafeTransactionViewController/ReviewSafeTransactionViewController.swift
@@ -104,7 +104,7 @@ class ReviewSafeTransactionViewController: UIViewController {
 
         let descriptionText = "An owner key will be used to confirm this transaction."
         let vc = ChooseOwnerKeyViewController(
-            owners: keys,
+            owners: { keys },
             chainID: self.safe.chain!.id,
             header: .text(description: descriptionText)
         ) { [weak self] keyInfo in

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/RejectionConfirmationViewController/RejectionConfirmationViewController.swift
@@ -79,7 +79,7 @@ class RejectionConfirmationViewController: UIViewController {
 
         let descriptionText = "You are about to create an on-chain rejection transaction. Please select which owner key to use."
         let vc = ChooseOwnerKeyViewController(
-            owners: rejectors,
+            owners: { rejectors },
             chainID: safe.chain!.id,
             header: .text(description: descriptionText)
         ) { [weak self] keyInfo in

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
@@ -85,10 +85,11 @@ class TransactionDetailCellBuilder {
 
     func buildFactoryUsed(_ creationTx: SCGModels.TxInfo.Creation) {
         if let factory = creationTx.factory?.value.address {
+            let info = NamingPolicy.name(for: factory, chainId: chain.id!)
             address(factory,
-                    label: creationTx.factory?.name,
+                    label: info.name ?? creationTx.factory?.name ?? "Unknown",
                     title: "Factory used",
-                    imageUri: creationTx.factory?.logoUri,
+                    imageUri: info.imageUri ?? creationTx.factory?.logoUri,
                     browseURL: chain.browserURL(address: factory.checksummed),
                     prefix: chain.shortName)
         } else {
@@ -98,11 +99,12 @@ class TransactionDetailCellBuilder {
 
     func buildMasterCopyUsed(_ creationTx: SCGModels.TxInfo.Creation) {
         if let implementation = creationTx.implementation?.value.address {
+            let info = NamingPolicy.name(for: implementation, chainId: chain.id!)
             address(
                 implementation,
-                label: creationTx.implementation?.name ?? "Unknown",
+                label: info.name ?? creationTx.implementation?.name ?? "Unknown",
                 title: "Base contract used",
-                imageUri: creationTx.implementation?.logoUri,
+                imageUri: info.imageUri ?? creationTx.implementation?.logoUri,
                 browseURL: chain.browserURL(address: implementation.checksummed),
                 prefix: chain.shortName)
         } else {

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailsViewController.swift
@@ -284,7 +284,7 @@ class TransactionDetailsViewController: LoadableViewController, UITableViewDataS
         }
         let descriptionText = "You are about to confirm this transaction. This happens off-chain. Please select which owner key to use."
         let vc = ChooseOwnerKeyViewController(
-            owners: signers,
+            owners: { signers },
             chainID: safe.chain!.id,
             header: .text(description: descriptionText)
         ) {

--- a/Multisig/UI/UI Library/Views/AddressInfoView.swift
+++ b/Multisig/UI/UI Library/Views/AddressInfoView.swift
@@ -15,51 +15,56 @@ class AddressInfoView: UINibView {
     @IBOutlet private weak var addressLabel: UILabel!
     @IBOutlet private weak var copyButton: UIButton!
     @IBOutlet private var detailButton: UIButton!
-
+    
     @IBOutlet weak var iconHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var iconWidthConstraint: NSLayoutConstraint!
-
+    
     static let defaultIconSize: CGFloat = 36
-
+    
     private(set) var address: Address!
     private(set) var ensName: String?
     private(set) var browseURL: URL?
     private(set) var prefix: String?
     private(set) var label: String?
     private(set) var copyAddressEnabled: Bool = true
-
+    
+    private(set) var addToContactsGestureRecognizer: UILongPressGestureRecognizer!
+    
     var copyEnabled: Bool {
         get { !copyButton.isHidden }
         set { copyButton.isHidden = !newValue }
     }
-
+    
     override func commonInit() {
         super.commonInit()
         titleLabel.setStyle(.headline)
         textLabel.setStyle(.headline)
         addressLabel.setStyle(.bodyTertiary)
         setTitle(nil)
-
+        
         setIconSize(Self.defaultIconSize)
-
+        
+        addToContactsGestureRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(addToContacts))
+        copyButton.addGestureRecognizer(addToContactsGestureRecognizer)
+        
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(displayAddress),
                                                name: .chainSettingsChanged,
                                                object: nil)
     }
-
+    
     func setIconSize(_ value: CGFloat) {
         iconWidthConstraint.constant = value
         iconHeightConstraint.constant = value
         setNeedsUpdateConstraints()
     }
-
+    
     func setTitle(_ text: String?, style: GNOTextStyle = .headline) {
         titleLabel.setStyle(style)
         titleLabel.text = text
         titleLabel.isHidden = text == nil
     }
-
+    
     /// Configures the address view
     /// - Parameters:
     ///   - address: the address for the identicon and address label
@@ -82,7 +87,7 @@ class AddressInfoView: UINibView {
         self.browseURL = browseURL
         self.prefix = prefix
         self.label = label
-
+        
         if let label = label {
             textLabel.isHidden = false
             textLabel.text = label
@@ -90,7 +95,7 @@ class AddressInfoView: UINibView {
         } else {
             textLabel.isHidden = true
         }
-
+        
         displayAddress()
         addressLabel.textAlignment = showIdenticon ? .left : .center
         if showIdenticon {
@@ -99,7 +104,7 @@ class AddressInfoView: UINibView {
         identiconView.isHidden = !showIdenticon
         detailButton.isHidden = browseURL == nil
     }
-
+    
     // show address with identicon, and show label or address ellipsized.
     func setAddressOneLine(
         _ address: Address,
@@ -116,52 +121,58 @@ class AddressInfoView: UINibView {
         self.browseURL = nil
         self.prefix = prefix
         self.label = label
-
+        
         textLabel.isHidden = false
         if let label = label {
             textLabel.text = label
         } else {
             textLabel.text = prependingPrefixString() + self.address.ellipsized()
         }
-
+        
         if !hideAddress {
             displayAddress()
         } else {
             addressLabel.isHidden = true
         }
-
+        
         identiconView.isHidden = false
         identiconView.set(address: address,
                           imageURL: imageUri,
                           placeholderImage: placeholderImage,
                           badgeName: badgeName)
-
+        
         detailButton.isHidden = browseURL == nil
     }
-
+    
     @IBAction private func didTapDetailButton() {
         UIApplication.shared.sendAction(#selector(UIViewController.didTapAddressInfoDetails(_:)), to: nil, from: self, for: nil)
     }
-
+    
+    @objc private func addToContacts() {
+        if addToContactsGestureRecognizer.state == .began {
+            UIApplication.shared.sendAction(#selector(UIViewController.addToContacts(_:)), to: nil, from: self, for: nil)
+        }
+    }
+    
     func setCopyAddressEnabled(_ enabled: Bool) {
         self.copyAddressEnabled = enabled
         self.copyButton.isEnabled = enabled
     }
-
+    
     @IBAction private func copyAddress() {
         guard copyAddressEnabled else { return }
         Pasteboard.string = copyPrefixString() + address.checksummed
         App.shared.snackbar.show(message: "Copied to clipboard", duration: 2)
     }
-
+    
     @IBAction private func didTouchDown(sender: UIButton, forEvent event: UIEvent) {
         alpha = 0.7
     }
-
+    
     @IBAction private func didTouchUp(sender: UIButton, forEvent event: UIEvent) {
         alpha = 1.0
     }
-
+    
     @objc func displayAddress() {
         addressLabel.isHidden = false
         if let ensName = ensName {
@@ -173,19 +184,19 @@ class AddressInfoView: UINibView {
             addressLabel.attributedText = (prefixString + self.address.checksummed).highlight(prefix: prefixString.count + 6)
         }
     }
-
+    
     private func copyPrefixString() -> String {
         AppSettings.copyAddressWithChainPrefix ? prefixString() : ""
     }
-
+    
     private func prependingPrefixString() -> String {
         AppSettings.prependingChainPrefixToAddresses ? prefixString() : ""
     }
-
+    
     private func prefixString() -> String {
         prefix != nil ? "\(prefix!):" : ""
     }
-
+    
 }
 
 extension UIViewController {
@@ -193,5 +204,85 @@ extension UIViewController {
         if let url = sender.browseURL {
             openInSafari(url)
         }
+    }
+    
+    @objc func addToContacts(_ view: AddressInfoView) {
+        if let contact = view.address, let cgChain = SCGModels.Chain.createFromCurrentChain() {
+            let createAddressBookEntryVC = CreateAddressBookEntryViewController()
+            createAddressBookEntryVC.inputAddress = contact
+            createAddressBookEntryVC.chain = cgChain
+            createAddressBookEntryVC.canEditAddress = false
+            
+            var inputName: String?
+            
+            enum EntryType { case safe, keyInfo, addressBook }
+            var entryType: EntryType
+            
+            if let safe = Safe.by(address: contact.checksummed, chainId: cgChain.id) {
+                inputName = safe.name
+                entryType = .safe
+            } else if let keyInfo = (try? KeyInfo.keys(addresses: [contact]))?.first {
+                inputName = keyInfo.name
+                entryType = .keyInfo
+            } else if let entry = AddressBookEntry.by(address: contact.checksummed, chainId: cgChain.id) {
+                inputName = entry.name
+                entryType = .addressBook
+            } else {
+                inputName = nil
+                entryType = .addressBook
+            }
+            
+            if let name = inputName {
+                createAddressBookEntryVC.inputName = name
+                
+                createAddressBookEntryVC.screenTitle = "Edit entry"
+                createAddressBookEntryVC.actionName = "Save"   
+            }
+            
+            createAddressBookEntryVC.completion = { [unowned createAddressBookEntryVC] (address, name) in
+                createAddressBookEntryVC.dismiss(animated: true) {
+                    switch entryType {
+                    case .safe:
+                        if let safe = Safe.by(address: address.checksummed, chainId: createAddressBookEntryVC.chain.id) {
+                            safe.update(name: name)
+                        }
+                    case .keyInfo:
+                        if let keyInfo = try? KeyInfo.keys(addresses: [address]).first {
+                            OwnerKeyController.edit(keyInfo: keyInfo, name: name)
+                        }
+                    case .addressBook:
+                        fallthrough
+                    default:
+                        if let cdChain = Chain.by(createAddressBookEntryVC.chain.id) {
+                            AddressBookEntry.addOrUpdate(address.checksummed, chain: cdChain, name: name)
+                        }
+                    }
+                }
+            }
+            let nav = ViewControllerFactory.modalWithRibbon(viewController: createAddressBookEntryVC,
+                                                            storedChain: try? Safe.getSelected()?.chain)
+            present(nav, animated: true)
+        }
+    }
+}
+
+extension SCGModels.Chain {
+    static func createFromCurrentChain() -> SCGModels.Chain? {
+        let cdChain = (try? Safe.getSelected()?.chain) ?? Chain.mainnetChain()
+        guard let prefixName = cdChain.shortName, let cdChainId = cdChain.id else {
+            return nil
+        }
+        return SCGModels.Chain(
+            chainId: UInt256String(stringLiteral: cdChainId),
+            chainName: "",
+            rpcUri: SCGModels.RpcAuthentication(authentication: SCGModels.RpcAuthentication.Authentication.none, value: URL(string: "https://app.safe.global/")!),
+            blockExplorerUriTemplate: SCGModels.BlockExplorerUriTemplate(address: "", txHash: ""),
+            nativeCurrency: SCGModels.Currency(name: "", symbol: "", decimals: 0, logoUri: URL(string: "https://app.safe.global/favicon.ico")!),
+            theme: SCGModels.Theme(textColor: "", backgroundColor: ""),
+            ensRegistryAddress: nil,
+            shortName: prefixName,
+            l2: true,
+            features: [],
+            gasPrice: [])
     }
 }


### PR DESCRIPTION
Handles #3415.
Handles #3416.

Changes proposed in this pull request:
* Add new "owner key list updated" internal notification
* Add "owner keys" option to the "select address" screen used in the safe creation
* Add long press gesture to an addresses to create or edit address book entry (or safe name, or owner key name) (GH-3416).
