### PR TITLE
feat: support import of 1.4.1 safes

### DIFF
--- a/Multisig/Logic/Ethereum/GnosisSafe.swift
+++ b/Multisig/Logic/Ethereum/GnosisSafe.swift
@@ -18,7 +18,7 @@ class GnosisSafe {
     }
 
     var minimumSupportedVersionValue = "1.0.0"
-    var maximumSupportedVersionValue = "1.3.0"
+    var maximumSupportedVersionValue = "1.4.1"
     private var minimumSupportedVersion: Version { Version(minimumSupportedVersionValue)! }
     private var maximumSupportedVersion: Version { Version(maximumSupportedVersionValue)! }
 


### PR DESCRIPTION
When trying to import safes created with version 1.4.1 the app was not allowing the user to continue as the safe was not supported. 

Changes proposed in this pull request:
- update the max supported version.