### PR TITLE
feat: add rudimentary decoding for stake txs

### DIFF
--- a/Multisig/Data/Services/Safe Client Gateway Service/SCGModels.swift
+++ b/Multisig/Data/Services/Safe Client Gateway Service/SCGModels.swift
@@ -176,6 +176,7 @@ extension SCGModels {
         case swapOrder(SwapOrder)
         case swapTransfer(SwapOrder)
         case twapOrder(TwapOrder)
+        case stake(Stake)
         case unknown
 
         init(from decoder: Decoder) throws {
@@ -206,6 +207,8 @@ extension SCGModels {
                 self = try .swapTransfer(SwapOrder(from: decoder))
             case "TwapOrder":
                 self = try .twapOrder(TwapOrder(from: decoder))
+            case "NativeStakingDeposit", "NativeStakingValidatorsExit", "NativeStakingWithdraw":
+                self = try .stake(Stake(from: decoder))
             case "Unknown":
                 fallthrough
             default:
@@ -381,6 +384,31 @@ extension SCGModels {
             var transactionHash: DataString
             var implementation: AddressInfo?
             var factory: AddressInfo?
+        }
+        
+        struct Stake: Decodable {
+            let type: StakeType
+            
+            var displayName: String {
+                return type.displayName
+            }
+        }
+        
+        enum StakeType: String, Decodable {
+            case deposit = "NativeStakingDeposit"
+            case validatorsExit = "NativeStakingValidatorsExit"
+            case withdraw = "NativeStakingWithdraw"
+
+            var displayName: String {
+                switch self {
+                case .deposit:
+                    return "Stake"
+                case .validatorsExit:
+                    return "Withdraw request"
+                case .withdraw:
+                    return "Claim"
+                }
+            }
         }
 
         struct SwapOrder: Decodable {

--- a/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
+++ b/Multisig/UI/Transaction/TransactionDetailsViewController/TransactionDetailCellBuilder.swift
@@ -382,6 +382,9 @@ class TransactionDetailCellBuilder {
             externalURL(text: "Order details", url: orderInfo.explorerUrl)
         case .twapOrder(let order):
             text(order.displayName, title: "Contract Interaction", expandableTitle: nil, copyText: nil)
+        case .stake(let stake):
+            text(stake.displayName, title: "Contract Interaction", expandableTitle: nil, copyText: nil)
+        
         case .creation(_):
             // ignore
             fallthrough
@@ -674,6 +677,9 @@ class TransactionDetailCellBuilder {
             icon = UIImage(named: "ico-custom-tx")
         case .twapOrder(let order):
             type = order.displayName
+            icon = UIImage(named: "ico-custom-tx")
+        case .stake(let stake):
+            type = stake.displayName
             icon = UIImage(named: "ico-custom-tx")
         case .unknown:
             type = "Unknown operation"

--- a/Multisig/UI/Transaction/TransactionListViewController/TransactionListViewController.swift
+++ b/Multisig/UI/Transaction/TransactionListViewController/TransactionListViewController.swift
@@ -374,6 +374,9 @@ class TransactionListViewController: LoadableViewController, UITableViewDelegate
         case .twapOrder(let order):
             image = UIImage(named: "ico-custom-tx")
             title = order.displayName
+        case .stake(let stake):
+            image = UIImage(named: "ico-custom-tx")
+            title = stake.displayName
         case .unknown:
             image = UIImage(named: "ico-custom-tx")
             title = "Unknown operation"

--- a/Multisig/UI/WalletConnect/Server/Safes/Incoming Transaction/WCIncomingTransactionRequestViewController.swift
+++ b/Multisig/UI/WalletConnect/Server/Safes/Incoming Transaction/WCIncomingTransactionRequestViewController.swift
@@ -146,6 +146,9 @@ class WCIncomingTransactionRequestViewController: ReviewSafeTransactionViewContr
         case .twapOrder(let order):
             imageName = "ico-custom-tx"
             name = order.displayName
+        case .stake(let stake):
+            imageName = "ico-custom-tx"
+            name = stake.displayName
         case .unknown:
             imageName = "ico-custom-tx"
             name = "Unknown operation"

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -25,7 +25,7 @@ set -o pipefail && \
 xcrun xcodebuild test \
     -project Multisig.xcodeproj \
     -scheme "$XCODE_SCHEME" \
-    -destination "platform=iOS Simulator,name=iPhone 15 Pro" \
+    -destination "platform=iOS Simulator,name=iPhone 16 Pro" \
     -resultBundlePath "$TEST_BUNDLE_PATH" \
 | tee "$OUTPUT_DIR/xcodebuild-test.log" | xcpretty -c -r junit
 


### PR DESCRIPTION
Instead of showing “unknown operation” we now display the type of stake tx.
Without this any stake TXs are shown as unkown operations:
![grafik](https://github.com/user-attachments/assets/30e9566b-c4fb-4cbb-ba3e-9c5592dce3de)
![grafik](https://github.com/user-attachments/assets/6600f39b-fd98-4157-9484-3839a8aa58eb)

With the changes stake txs are shown as follows:
![grafik](https://github.com/user-attachments/assets/eeb9159e-3d43-4267-bfbf-31cde1c38c93)
![simulator_screenshot_1C36DE66-02F0-4839-BC77-956B4BD23AB0](https://github.com/user-attachments/assets/e57dd78e-7e5d-4931-a727-e4317c38c0ab)
![simulator_screenshot_4030DAD2-8EC0-4351-A520-668B6FECA92E](https://github.com/user-attachments/assets/d77e9a47-7d7d-4fce-9313-0c85b1fbcb4a)

Changes proposed in this pull request:
-
-
-
